### PR TITLE
fix: add bank account to payment entry form

### DIFF
--- a/check_run/check_run/doctype/check_run/check_run.py
+++ b/check_run/check_run/doctype/check_run/check_run.py
@@ -138,6 +138,7 @@ class CheckRun(Document):
 				pe.posting_date = nowdate()
 				pe.mode_of_payment = group[0].mode_of_payment
 				pe.company = self.company
+				pe.bank_account = self.bank_account
 				pe.paid_from = gl_account
 				pe.paid_to = self.pay_to_account
 				pe.paid_to_account_currency = frappe.db.get_value("Account", self.bank_account, "account_currency")


### PR DESCRIPTION
Small fix. I was testing functionality with the test data by paying via check for one bill, and noticed it didn't show up on the Positive Pay report. I checked the `Payment Entry` database and saw the field for `bank_account` was `NULL` (what Positive Pay uses to filter) for the transaction. I added a line in the python to save that field and the Positive Pay report seems to be working now.