### PR TITLE
test: refactor existing Cypress tests and add Check Run Settings tests

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -5,6 +5,7 @@
 	"video": false,
 	"screenshotOnRunFailure": false,
 	"pageLoadTimeout": 15000,
+	"watchForFileChanges": false,
 	"retries": {
 		"runMode": 2,
 		"openMode": 0

--- a/cypress/integration/check_run.spec.js
+++ b/cypress/integration/check_run.spec.js
@@ -14,6 +14,11 @@ context('Check Run List', () => {
 		cy.get('.btn-primary').contains('Start Check Run').should('be.visible').click()
 	})
 
+	// Incorporate new 'Confirm settings' prompt
+	it("Confirm Settings", () => {
+		cy.get_open_dialog().contains('Yes').should('be.visible').click()
+	})
+
 	it("Complete First Check Run", () => {
 		cy.visit('/app/check-run/ACC-CR-2022-00001')
 		cy.fill_field("end_date", "1/1").blur()

--- a/cypress/integration/check_run.spec.js
+++ b/cypress/integration/check_run.spec.js
@@ -50,10 +50,11 @@ context('Check Run List', () => {
 		cy.get('.indicator-pill').should('contain', 'Submitted').wait(250)
 		cy.get('.indicator-pill').should('contain', 'Ready to Print').wait(15000)
 	})
-	// 403 Forbidden errors crop up when following tests try to navigate when run in sequence:
+
 	it("Create Check Run Settings From List", () => {  // TEST WORKS
-		cy.wait(3000)
-		cy.go_to_list('Check Run Settings')  // throwing 403 Forbidden error when run in sequence
+		cy.visit('/login')  // Re-login to avoid 403 Forbidden errors
+		cy.login()
+		cy.go_to_list('Check Run Settings')
 		cy.wait(1000)
 		cy.get('.primary-action').contains('Add Check Run Settings').should('be.visible').click()
 		cy.wait(1000)
@@ -64,7 +65,7 @@ context('Check Run List', () => {
 
 	it("Complete Payroll Check Run", () => {  // TEST WORKS
 		cy.wait(3000)
-		cy.go_to_list('Check Run')  // throwing 403 Forbidden error when run in sequence
+		cy.go_to_list('Check Run')
 		cy.get('.primary-action').contains('Add Check Run').should('be.visible').click()
 		cy.wait(1000)
 		cy.get('.modal [data-fieldname="pay_to_account"] input').clear().type('2120 - Payroll Payable - CFC').blur()

--- a/cypress/integration/check_run.spec.js
+++ b/cypress/integration/check_run.spec.js
@@ -5,24 +5,40 @@ context('Check Run List', () => {
 		cy.go_to_list('Check Run')
 	})
 
-	it("Add Check Run", () => {
+	it("Add Check Run", () => {  // TEST WORKS
 		cy.get('.primary-action').contains('Add Check Run').should('be.visible').click()
 		cy.wait(1000)
-		cy.get_field('company').focus().should('be.visible')
+		cy.get_field('company').focus().should('be.visible')  // May not be grabbing field from modal, but background table
 		cy.get_field('bank_account').focus().should('be.visible')
-		cy.get_field('pay_to_account').focus().should('be.visible')
+		cy.get_field('pay_to_account').focus().should('be.visible')  // May not be grabbing field from modal, but background table
 		cy.get('.btn-primary').contains('Start Check Run').should('be.visible').click()
 	})
 
-	// Incorporate new 'Confirm settings' prompt
-	it("Confirm Settings", () => {
+	it("Confirm Default Check Run Settings", () => {  // TEST WORKS
+		cy.wait(1000)
 		cy.get_open_dialog().contains('Yes').should('be.visible').click()
+		cy.wait(1000)
+		cy.get_field('include_purchase_invoices').should('be.checked')
+		cy.get_field('include_journal_entries').should('be.checked')
+		cy.get_field('include_expense_claims').should('be.checked')
+		cy.get_field('pre_check_overdue_items').should('not.be.checked')
+		cy.get_field('allow_cancellation').should('not.be.checked')
+		cy.get_field('cascade_cancellation').should('not.be.checked')
+		cy.get_field('number_of_invoices_per_voucher').should('have.value', 0)
+		cy.get_field('ach_file_extension').should('have.value', 'ach')
+		cy.get_field('ach_service_class_code', 'Select').find('option:selected').should('have.text', '200')
+		cy.get_field('ach_standard_class_code', 'Select').find('option:selected').should('have.text', 'PPD')
+		cy.get_field('ach_description').should('be.empty')
+		cy.get('.btn-primary').contains('Save').should('be.visible').click().wait(500)
+		cy.go('back')
 	})
 
-	it("Complete First Check Run", () => {
-		cy.visit('/app/check-run/ACC-CR-2022-00001')
-		cy.fill_field("end_date", "1/1").blur()
-		cy.fill_field("posting_date", "1/1").blur()
+	it("Complete First Check Run", () => {  // TEST WORKS
+		cy.wait(3000)
+		// cy.visit('/app/check-run/ACC-CR-2022-00001')  // Throwing 403 Forbidden error when run in sequence
+		cy.fill_field('end_date', '1/1', 'Date').blur()
+		cy.fill_field('posting_date', '1/1', 'Date').blur()
+		cy.wait(1000)  // Let date field change register
 		cy.get('[data-checkbox-index="0"]').click().wait(250)
 		cy.get('[data-fieldname="amount_check_run"]').get('.like-disabled-input').should('contain', '$ 1,800.00')
 		cy.get('body').type(' ').wait(250)
@@ -34,13 +50,28 @@ context('Check Run List', () => {
 		cy.get('.indicator-pill').should('contain', 'Submitted').wait(250)
 		cy.get('.indicator-pill').should('contain', 'Ready to Print').wait(15000)
 	})
+	// 403 Forbidden errors crop up when following tests try to navigate when run in sequence:
+	it("Create Check Run Settings From List", () => {  // TEST WORKS
+		cy.wait(3000)
+		cy.go_to_list('Check Run Settings')  // throwing 403 Forbidden error when run in sequence
+		cy.wait(1000)
+		cy.get('.primary-action').contains('Add Check Run Settings').should('be.visible').click()
+		cy.wait(1000)
+		cy.fill_field('bank_account', 'Primary Checking - Local Bank').blur().wait(500)
+		cy.fill_field('pay_to_account', '2120 - Payroll Payable - CFC').blur().wait(500)
+		cy.get('.btn-primary').contains('Save').should('be.visible').click()
+	})
 
-	it("Complete Second Check Run", () => {
-		cy.get('body').type('{ctrl+b}').wait(500)
-		cy.fill_field("end_date", "1/1").blur()
-		cy.fill_field("posting_date", "1/1").blur()
-		cy.get_field("pay_to_account").type("{ctrl+home}{del}").blur().wait(100)
-		cy.fill_field("pay_to_account", "2120 - Payroll Payable - CFC").blur().wait(500)
+	it("Complete Payroll Check Run", () => {  // TEST WORKS
+		cy.wait(3000)
+		cy.go_to_list('Check Run')  // throwing 403 Forbidden error when run in sequence
+		cy.get('.primary-action').contains('Add Check Run').should('be.visible').click()
+		cy.wait(1000)
+		cy.get('.modal [data-fieldname="pay_to_account"] input').clear().type('2120 - Payroll Payable - CFC').blur()
+		cy.get('.btn-primary').contains('Start Check Run').should('be.visible').click()
+		cy.fill_field('end_date', '1/1', 'Date').blur()
+		cy.fill_field('posting_date', '1/1', 'Date').blur()
+		cy.wait(1000)  // Let date field change register
 		cy.get('#select-all').click()
 		cy.get('.primary-action').contains('Save').should('be.visible').click()
 		cy.get('.primary-action').contains('Submit').should('be.visible').click().wait(250)

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -150,7 +150,7 @@ Cypress.Commands.add('fill_field', (fieldname, value, fieldtype = 'Data') => {
 	cy.get_field(fieldname, fieldtype).as('input');
 
 	if (['Date', 'Time', 'Datetime'].includes(fieldtype)) {
-		cy.get('@input').click().wait(200);
+		cy.get('@input').clear().wait(200);
 		cy.get('.datepickers-container .datepicker.active').should('exist');
 	}
 	if (fieldtype === 'Time') {


### PR DESCRIPTION
These tests all individually pass, and the first three run in sequence without issues. But even with substantial `wait` times between tests, they're throwing `403 Forbidden` errors when Cypress tries to navigate where the test says to. I'm still trying to work out what's going on under the hood here.