### PR TITLE
Add max length 10 for ACH Description field

### DIFF
--- a/check_run/check_run/doctype/check_run/check_run.py
+++ b/check_run/check_run/doctype/check_run/check_run.py
@@ -571,7 +571,7 @@ def build_nacha_file_from_payment_entries(doc, payment_entries, settings):
 		company_discretionary_data=company_discretionary_data[:20],
 		company_id=company_ach_id,
 		standard_class_code=settings.ach_standard_class_code,
-		company_entry_description=settings.ach_description or "",
+		company_entry_description=settings.ach_description[:10] or "",
 		company_descriptive_date=None,
 		effective_entry_date=getdate(),
 		settlement_date=None,

--- a/check_run/check_run/doctype/check_run_settings/check_run_settings.json
+++ b/check_run/check_run/doctype/check_run_settings/check_run_settings.json
@@ -132,6 +132,7 @@
    "fieldname": "ach_description",
    "fieldtype": "Data",
    "label": "ACH Description"
+   "length": 10
   },
   {
    "fieldname": "print_format",

--- a/check_run/check_run/doctype/check_run_settings/check_run_settings.json
+++ b/check_run/check_run/doctype/check_run_settings/check_run_settings.json
@@ -131,7 +131,7 @@
   {
    "fieldname": "ach_description",
    "fieldtype": "Data",
-   "label": "ACH Description"
+   "label": "ACH Description",
    "length": 10
   },
   {
@@ -174,7 +174,7 @@
   }
  ],
  "links": [],
- "modified": "2023-03-16 12:04:20.854283",
+ "modified": "2023-03-16 12:07:20.854283",
  "modified_by": "Administrator",
  "module": "Check Run",
  "name": "Check Run Settings",

--- a/check_run/check_run/doctype/check_run_settings/check_run_settings.json
+++ b/check_run/check_run/doctype/check_run_settings/check_run_settings.json
@@ -174,7 +174,7 @@
   }
  ],
  "links": [],
- "modified": "2023-03-10 12:33:20.854283",
+ "modified": "2023-03-16 12:04:20.854283",
  "modified_by": "Administrator",
  "module": "Check Run",
  "name": "Check Run Settings",


### PR DESCRIPTION
Add maximum length 10 for ACH Description to maintain proper format of batch header in NACHA file output.