### PR TITLE
Use Posting Date for Effective Entry Date

### DIFF
--- a/check_run/check_run/doctype/check_run/check_run.py
+++ b/check_run/check_run/doctype/check_run/check_run.py
@@ -578,7 +578,7 @@ def build_nacha_file_from_payment_entries(doc, payment_entries, settings):
 		standard_class_code=settings.ach_standard_class_code,
 		company_entry_description=ach_description[:10] or "",
 		company_descriptive_date=None,
-		effective_entry_date=getdate(),
+		effective_entry_date=doc.posting_date,
 		settlement_date=None,
 		originator_status_code=1,
 		originating_dfi_id=company_bank_account_no,

--- a/docs/achgeneration.md
+++ b/docs/achgeneration.md
@@ -14,6 +14,7 @@ Other fields available to help configure your ACH generation include:
 - Company Discretionary Data, also in the Batch header
 - Immediate Origin, which can override the ABA number that the bank is expecting
 - Custom Post Processing Hook, which allows you to provide a custom function to further manipulate the ACH file. For example, Royal Bank of Canada requires a non-standard first line.
+- Posting Date, which becomes the "Effective Entry Date" in the ACH Batch Header
 
 The 'Custom Post Processing Hook' is a read-only field and not intended to be set by non-technical users. The RBC example noted above can be set by entering the following into the browser console: `cur_frm.set_value('custom_post_processing_hook','check_run.test_setup.example_post_processing_hook')`. Provide the dotted path to your function with a signature matching that of the example.
 


### PR DESCRIPTION
The Posting Date will be used for the Effective Entry Date in the ACH Batch Header, and the documentation has been updated to reflect this.