### PR TITLE
The hook jenv is deprecated New variable is jinja

### DIFF
--- a/check_run/hooks.py
+++ b/check_run/hooks.py
@@ -174,8 +174,8 @@ override_doctype_class = {
 # For example: Role, Gender, etc.
 # translated_search_doctypes = []
 
-jenv = {
+jinja = {
 	"methods": [
-		"get_default_address:frappe.contacts.doctype.address.address.get_default_address"
+		"frappe.contacts.doctype.address.address.get_default_address"
 	]
 }


### PR DESCRIPTION
**As Patch mentioned in Frappe on given url**
**apps/frappe/frappe/patches/v13_0/jinja_hooks.py**

File mentions that **jenv** is depricated, New variable is **jinja** 

![image](https://user-images.githubusercontent.com/14124603/231165979-b8dc99f5-0218-422b-88d7-3f13cdba3f39.png)
