### PR TITLE
fix: broken translation string in csv

### DIFF
--- a/check_run/check_run/doctype/check_run_settings/check_run_settings.json
+++ b/check_run/check_run/doctype/check_run_settings/check_run_settings.json
@@ -95,7 +95,7 @@
 		},
 		{
 			"default": "0",
-			"description": "When a Check Run is cancelled, all Payment Entries linked to it will also be cancelled. This is not recommended. ",
+			"description": "When a Check Run is cancelled, all Payment Entries linked to it will also be cancelled. This is not recommended.",
 			"fieldname": "cascade_cancellation",
 			"fieldtype": "Check",
 			"label": "Cascade Cancellation"

--- a/check_run/translations/en-GB.csv
+++ b/check_run/translations/en-GB.csv
@@ -1,18 +1,18 @@
-Amount in Check Run, Amount in Cheque Run,
-Check Run, Cheque Run,
-Check Run List, Cheque Run List,
-Check Run End Date, Cheque Run End Date,
-Check Run Settings, Cheque Run Settings,
-Final Check Number, Final Cheque Number,
-Initial Check Number, Initial Cheque Number,
-Payment Entries will be unlinked when Check Run is cancelled, Payment Entries will be unlinked when Cheque Run is cancelled,
-Pre-Check all payables that have a due date greater than the Check Run's posting date, Pre-Check all payables that have a due date greater than the Cheque Run's posting date,
-"""When a Check Run is cancelled,  all Payment Entries linked to it will also be cancelled. This is not recommended. """, """When a Cheque Run is cancelled,  all Payment Entries linked to it will also be cancelled. This is not recommended. """,
-Last Used Check Number, Last Used Cheque Number,
-ABA Number, DFI Routing Number,
-The settings for this Check Run do not allow cancellation, The settings for this Cheque Run do not allow cancellation,
-Company Bank ABA Number missing for {}, Company Bank DFI Routing Number missing for {},
-This Bank is linked to at least one Canadian address. Canadian banking institutions require the ABA Number must not exceed 8 characters., This Bank is linked to at least one Canadian address. Canadian banking institutions require the DFI Routing Number must not exceed 8 characters.,
-Download Checks, Download Cheques,
-New Initial Check Number, New Initial Cheque Number,
-Re-Print Checks, Re-Print Cheques,
+Amount in Check Run, Amount in Cheque Run
+Check Run, Cheque Run
+Check Run List, Cheque Run List
+Check Run End Date, Cheque Run End Date
+Check Run Settings, Cheque Run Settings
+Final Check Number, Final Cheque Number
+Initial Check Number, Initial Cheque Number
+Payment Entries will be unlinked when Check Run is cancelled, Payment Entries will be unlinked when Cheque Run is cancelled
+Pre-Check all payables that have a due date greater than the Check Run's posting date, Pre-Check all payables that have a due date greater than the Cheque Run's posting date
+"When a Check Run is cancelled, all Payment Entries linked to it will also be cancelled. This is not recommended.","When a Cheque Run is cancelled, all Payment Entries linked to it will also be cancelled. This is not recommended."
+Last Used Check Number, Last Used Cheque Number
+ABA Number, DFI Routing Number
+The settings for this Check Run do not allow cancellation, The settings for this Cheque Run do not allow cancellation
+Company Bank ABA Number missing for {}, Company Bank DFI Routing Number missing for {}
+This Bank is linked to at least one Canadian address. Canadian banking institutions require the ABA Number must not exceed 8 characters., This Bank is linked to at least one Canadian address. Canadian banking institutions require the DFI Routing Number must not exceed 8 characters.
+Download Checks, Download Cheques
+New Initial Check Number, New Initial Cheque Number
+Re-Print Checks, Re-Print Cheques


### PR DESCRIPTION
Addresses #119 

A sneaky extra space in the string was preventing Frappe from matching it and substituting the translation. I also removed an extra trailing space in the original text. Because the string is in a `.json` file, this needs a `bench migrate` for the fix to be visible.

<img width="483" alt="Screenshot 2023-07-18 at 9 25 30 PM" src="https://github.com/agritheory/check_run/assets/9591826/6b498fa4-0919-4935-a734-2dfc440634e2">
