### PR TITLE
trans: add error message to translations

### DIFF
--- a/check_run/translations/en-GB.csv
+++ b/check_run/translations/en-GB.csv
@@ -16,3 +16,4 @@ This Bank is linked to at least one Canadian address. Canadian banking instituti
 Download Checks, Download Cheques
 New Initial Check Number, New Initial Cheque Number
 Re-Print Checks, Re-Print Cheques
+This document is currently selected for payment in draft Check Run {} and cannot be cancelled., This document is currently selected for payment in draft Cheque Run {} and cannot be cancelled.


### PR DESCRIPTION
Adds latest error message (from PR #126) to the translations csv file. As noted in the original translations PR, it doesn't appear that Frappe's system supports f-strings [yet], so on testing I don't see the translation coming through. (Ideally this is fixed at some point, so still good to have it in the translations list).