### PR TITLE
fix: skip check on draft check runs with no transactions (v13)

### DIFF
--- a/check_run/check_run/__init__.py
+++ b/check_run/check_run/__init__.py
@@ -17,6 +17,8 @@ def disallow_cancellation_if_in_check_run(doc, method=None):
 		"Check Run", ["name", "transactions"], {"docstatus": 0}
 	)
 	for draft_check_run in draft_check_runs:
+		if not draft_check_run.transactions:
+			continue
 		transactions = [
 			t.get("ref_number") or t.get("name")
 			for t in json.loads(draft_check_run.transactions)


### PR DESCRIPTION
Resolution for `TypeError: the JSON object must be str, bytes or bytearray, not NoneType` when draft check run has no transactions.