### PR TITLE
fix: always include payment term for purchase invoice

### DIFF
--- a/.github/validate_customizations.py
+++ b/.github/validate_customizations.py
@@ -41,7 +41,7 @@ def validate_module(customized_doctypes, set_module=False):
 	this_app = app_dir.stem
 	for doctype, customize_files in customized_doctypes.items():
 		for customize_file in customize_files:
-			if not this_app in str(customize_file):
+			if not this_app == customize_file.parent.parent.parent.parent.stem:
 				continue
 			module = customize_file.parent.parent.stem
 			file_contents = json.loads(customize_file.read_text())
@@ -87,7 +87,7 @@ def validate_no_custom_perms(customized_doctypes):
 	this_app = pathlib.Path(__file__).resolve().parent.parent.stem
 	for doctype, customize_files in customized_doctypes.items():
 		for customize_file in customize_files:
-			if not this_app in str(customize_file):
+			if not this_app == customize_file.parent.parent.parent.parent.stem:
 				continue
 			file_contents = json.loads(customize_file.read_text())
 			if file_contents.get("custom_perms"):

--- a/check_run/hooks.py
+++ b/check_run/hooks.py
@@ -110,6 +110,7 @@ doc_events = {
 	"Payment Entry": {
 		"validate": [
 			"check_run.overrides.payment_entry.validate_duplicate_check_number",
+			"check_run.overrides.payment_entry.validate_add_payment_term",
 		],
 		"on_submit": ["check_run.overrides.payment_entry.update_check_number"],
 	},

--- a/docs/payment_entry.md
+++ b/docs/payment_entry.md
@@ -9,3 +9,5 @@ This setting on Bank Account automatically fetches the Bank Account into the Pay
 
 ## Additional Customizations
 Check Run takes the opinion that there is no scenario where it it appropriate to cut a check without providing a reference document. Payment References has been customized to be required unless the Payment Entry is of type 'Internal Transfer'.
+
+Since the Purchase Invoices displayed in a Check Run are automatically split by their Payment Terms (if the invoice has a defined Payment Schedule), it's important that a Payment Entry for a portion of an invoice made outside of a Check Run properly links a Payment Reference to a Payment Term. Check Run includes a validation that attempts to fill this in, and warns the user to review. For more information, refer to the "Considerations for Purchase Invoices with Payment Schedules" section on the [Settings page](./settings.md).

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -75,6 +75,6 @@ Check Run leverages the built-in ERPNext mechanism that automatically updates an
 
 ![Screen shot of an example Payment Schedule defined in a purchase invoice. The Payment Term column of the table links to unique documents, name "Rental Installment 1", "Rental Installment 2", etc. for the different rows.](./assets/InvoicePaymentScheduleExample.png)
 
-2. If you're creating a Payment Entry outside of a Check Run that's for a portion of an invoice (to satisfy a Payment Term), there's a validation in place to make sure the Payment Term field in the Payment References table is filled in. If the Payment Entry covers multiple Payment Terms, there should be a row for each portion of the payment with a link to its respective Payment Term.
+2. If you're creating a Payment Entry outside of a Check Run that's for a portion of an invoice (to satisfy a Payment Term), there's a validation in place to check for and link to the most recent outstanding Payment Term. If the Payment Term field in the Payment References table is left blank, it attempts to fill in the field and warn the user to review. If the Payment Entry covers multiple Payment Terms, there should be a row for each portion of the payment with a link to its respective Payment Term.
 
 ![Screen shot of the form dialog when a row in the Payment References table is edited. The Payment Term field shows a value of "Rental Installment 3" to link the allocated amount of the payment to the appropriate term in the invoice's Payment Schedule.](./assets/PaymentEntryPaymentTerm.png)


### PR DESCRIPTION
Resolves #191 

This ended up being similar to the original validation (that was checking if a Purchase Invoice in any Payment Entry had a Payment Schedule, then throwing an error if there were o/s terms but that field were blank) but incorporating the changes discussed:

- [x] Only runs the validation if the `check_run` field is blank (aka when a user creates a one-off Payment Entry outside of a Check Run)
- [x] Attempts to fill in the field with the earliest-due Payment Term with any o/s balance. In the event the allocated amount is more than the Payment Term outstanding amount, ERPNext catches this and throws an error. The documentation explains that in such a case, the user needs to create multiple rows and allocate amounts to different payment terms
- [x] Prints a warning to let the user know that field were updated and suggests they review
- [x] Documentation is updated so this is explained in the Payment Entry page as well as the Settings section
- [x] A new function in `tests/setup.py` creates a one-off Payment Entry for the first Cooperative Ag invoice to pay $1,000 of the total $5,000. The validation code automatically assigns the Payment Term. On opening a Check Run (need to make sure as of date is end of Jan), it shows the correct o/s amount for that invoice of $4,000.

Edit: I edited the `validate_customizations.py` file because my bench folder is named `check_run` - the code that checks if the app is not in the str(path) to continue wasn't working right (kept picking up missing module keys in erpnext since "check_run" is always in my directory path).