### PR TITLE
Print Preview Override

### DIFF
--- a/check_run/check_run/custom/print_format.json
+++ b/check_run/check_run/custom/print_format.json
@@ -1,0 +1,32 @@
+{
+ "custom_fields": [],
+ "custom_perms": [],
+ "doctype": "Print Format",
+ "links": [],
+ "property_setters": [
+  {
+   "_assign": null,
+   "_comments": null,
+   "_liked_by": null,
+   "_user_tags": null,
+   "creation": "2024-05-08 20:12:54.589131",
+   "default_value": null,
+   "doc_type": "Print Format",
+   "docstatus": 0,
+   "doctype_or_field": "DocType",
+   "field_name": null,
+   "idx": 0,
+   "is_system_generated": 0,
+   "modified": "2024-05-08 20:12:54.589131",
+   "modified_by": "Administrator",
+   "module": "Check Run",
+   "name": "Print Format-main-search_fields",
+   "owner": "Administrator",
+   "property": "search_fields",
+   "property_type": "Data",
+   "row_name": null,
+   "value": "module, doc_type"
+  }
+ ],
+ "sync_on_migrate": 1
+}

--- a/check_run/check_run/doctype/check_run/check_run.json
+++ b/check_run/check_run/doctype/check_run/check_run.json
@@ -25,9 +25,7 @@
   "check_run_table",
   "transactions",
   "print_count",
-  "status",
-  "payment_entry_format",
-  "secondary_print_format"
+  "status"
  ],
  "fields": [
   {
@@ -158,23 +156,11 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Posting Date"
-  },
-  {
-   "fieldname": "payment_entry_format",
-   "fieldtype": "Link",
-   "label": "Payment Entry Format",
-   "options": "Print Format"
-  },
-  {
-   "fieldname": "secondary_print_format",
-   "fieldtype": "Link",
-   "label": "Secondary Print Format",
-   "options": "Print Format"
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2024-05-08 20:06:22.394409",
+ "modified": "2024-05-08 21:00:27.388330",
  "modified_by": "Administrator",
  "module": "Check Run",
  "name": "Check Run",

--- a/check_run/check_run/doctype/check_run/check_run.json
+++ b/check_run/check_run/doctype/check_run/check_run.json
@@ -1,196 +1,212 @@
 {
-	"actions": [],
-	"allow_copy": 1,
-	"allow_events_in_timeline": 1,
-	"autoname": "ACC-CR-.YYYY.-.#####",
-	"creation": "2018-05-22 14:01:11.307993",
-	"doctype": "DocType",
-	"editable_grid": 1,
-	"engine": "InnoDB",
-	"field_order": [
-		"end_date",
-		"posting_date",
-		"beg_balance",
-		"company_discretionary_data",
-		"column_break_3",
-		"initial_check_number",
-		"final_check_number",
-		"amount_check_run",
-		"column_break_6",
-		"company",
-		"bank_account",
-		"pay_to_account",
-		"amended_from",
-		"section_break_9",
-		"check_run_table",
-		"transactions",
-		"print_count",
-		"status"
-	],
-	"fields": [
-		{
-			"fieldname": "end_date",
-			"fieldtype": "Date",
-			"in_list_view": 1,
-			"label": "Check Run End Date"
-		},
-		{
-			"fieldname": "column_break_3",
-			"fieldtype": "Column Break"
-		},
-		{
-			"allow_on_submit": 1,
-			"fieldname": "initial_check_number",
-			"fieldtype": "Int",
-			"in_list_view": 1,
-			"label": "Initial Check Number"
-		},
-		{
-			"allow_on_submit": 1,
-			"fieldname": "final_check_number",
-			"fieldtype": "Int",
-			"in_list_view": 1,
-			"label": "Final Check Number",
-			"read_only": 1
-		},
-		{
-			"default": "0.00",
-			"fieldname": "amount_check_run",
-			"fieldtype": "Currency",
-			"in_list_view": 1,
-			"label": "Amount in Check Run",
-			"read_only": 1
-		},
-		{
-			"fieldname": "column_break_6",
-			"fieldtype": "Column Break"
-		},
-		{
-			"allow_in_quick_entry": 1,
-			"fieldname": "company",
-			"fieldtype": "Link",
-			"in_standard_filter": 1,
-			"label": "Company",
-			"options": "Company",
-			"remember_last_selected_value": 1,
-			"reqd": 1
-		},
-		{
-			"allow_in_quick_entry": 1,
-			"fetch_from": "company.default_bank_account",
-			"fetch_if_empty": 1,
-			"fieldname": "bank_account",
-			"fieldtype": "Link",
-			"label": "Paid From (Bank Account)",
-			"options": "Bank Account",
-			"remember_last_selected_value": 1,
-			"reqd": 1
-		},
-		{
-			"default": "company.default_payable_account",
-			"fieldname": "pay_to_account",
-			"fieldtype": "Link",
-			"in_standard_filter": 1,
-			"label": "Accounts Payable",
-			"options": "Account",
-			"remember_last_selected_value": 1,
-			"reqd": 1
-		},
-		{
-			"allow_on_submit": 1,
-			"depends_on": "eval:doc.docstatus==1",
-			"fieldname": "company_discretionary_data",
-			"fieldtype": "Data",
-			"label": "Company Discretionary Data",
-			"length": 20
-		},
-		{
-			"fieldname": "section_break_9",
-			"fieldtype": "Section Break"
-		},
-		{
-			"default": "0.00",
-			"fieldname": "beg_balance",
-			"fieldtype": "Currency",
-			"label": "Beginning Bank Account Balance",
-			"read_only": 1
-		},
-		{
-			"fieldname": "amended_from",
-			"fieldtype": "Link",
-			"hidden": 1,
-			"label": "Amended From",
-			"no_copy": 1,
-			"options": "Check Run",
-			"print_hide": 1,
-			"read_only": 1
-		},
-		{
-			"allow_on_submit": 1,
-			"fieldname": "transactions",
-			"fieldtype": "Long Text",
-			"hidden": 1,
-			"ignore_xss_filter": 1
-		},
-		{
-			"allow_on_submit": 1,
-			"fieldname": "print_count",
-			"fieldtype": "Int",
-			"hidden": 1
-		},
-		{
-			"allow_on_submit": 1,
-			"default": "Draft",
-			"fieldname": "status",
-			"fieldtype": "Select",
-			"hidden": 1,
-			"options": "Draft\nSubmitting\nSubmitted\nReady to Print\nConfirm Print\nPrinted"
-		},
-		{
-			"fieldname": "check_run_table",
-			"fieldtype": "HTML"
-		},
-		{
-			"fieldname": "posting_date",
-			"fieldtype": "Date",
-			"in_list_view": 1,
-			"in_standard_filter": 1,
-			"label": "Posting Date"
-		}
-	],
-	"is_submittable": 1,
-	"links": [],
-	"modified": "2023-03-10 12:28:36.910004",
-	"modified_by": "Administrator",
-	"module": "Check Run",
-	"name": "Check Run",
-	"owner": "Administrator",
-	"permissions": [
-		{
-			"create": 1,
-			"read": 1,
-			"report": 1,
-			"role": "Accounts User",
-			"select": 1,
-			"write": 1
-		},
-		{
-			"create": 1,
-			"export": 1,
-			"print": 1,
-			"read": 1,
-			"report": 1,
-			"role": "Accounts Manager",
-			"select": 1,
-			"share": 1,
-			"submit": 1,
-			"write": 1
-		}
-	],
-	"quick_entry": 1,
-	"sort_field": "modified",
-	"sort_order": "DESC",
-	"track_changes": 1,
-	"track_seen": 1,
-	"track_views": 1
+ "actions": [],
+ "allow_copy": 1,
+ "allow_events_in_timeline": 1,
+ "autoname": "ACC-CR-.YYYY.-.#####",
+ "creation": "2018-05-22 14:01:11.307993",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "end_date",
+  "posting_date",
+  "beg_balance",
+  "company_discretionary_data",
+  "column_break_3",
+  "initial_check_number",
+  "final_check_number",
+  "amount_check_run",
+  "column_break_6",
+  "company",
+  "bank_account",
+  "pay_to_account",
+  "amended_from",
+  "section_break_9",
+  "check_run_table",
+  "transactions",
+  "print_count",
+  "status",
+  "payment_entry_format",
+  "secondary_print_format"
+ ],
+ "fields": [
+  {
+   "fieldname": "end_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Check Run End Date"
+  },
+  {
+   "fieldname": "column_break_3",
+   "fieldtype": "Column Break"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "initial_check_number",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Initial Check Number"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "final_check_number",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Final Check Number",
+   "read_only": 1
+  },
+  {
+   "default": "0.00",
+   "fieldname": "amount_check_run",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Amount in Check Run",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_6",
+   "fieldtype": "Column Break"
+  },
+  {
+   "allow_in_quick_entry": 1,
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "in_standard_filter": 1,
+   "label": "Company",
+   "options": "Company",
+   "remember_last_selected_value": 1,
+   "reqd": 1
+  },
+  {
+   "allow_in_quick_entry": 1,
+   "fetch_from": "company.default_bank_account",
+   "fetch_if_empty": 1,
+   "fieldname": "bank_account",
+   "fieldtype": "Link",
+   "label": "Paid From (Bank Account)",
+   "options": "Bank Account",
+   "remember_last_selected_value": 1,
+   "reqd": 1
+  },
+  {
+   "default": "company.default_payable_account",
+   "fieldname": "pay_to_account",
+   "fieldtype": "Link",
+   "in_standard_filter": 1,
+   "label": "Accounts Payable",
+   "options": "Account",
+   "remember_last_selected_value": 1,
+   "reqd": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "depends_on": "eval:doc.docstatus==1",
+   "fieldname": "company_discretionary_data",
+   "fieldtype": "Data",
+   "label": "Company Discretionary Data",
+   "length": 20
+  },
+  {
+   "fieldname": "section_break_9",
+   "fieldtype": "Section Break"
+  },
+  {
+   "default": "0.00",
+   "fieldname": "beg_balance",
+   "fieldtype": "Currency",
+   "label": "Beginning Bank Account Balance",
+   "read_only": 1
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Check Run",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "transactions",
+   "fieldtype": "Long Text",
+   "hidden": 1,
+   "ignore_xss_filter": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "print_count",
+   "fieldtype": "Int",
+   "hidden": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "default": "Draft",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "hidden": 1,
+   "options": "Draft\nSubmitting\nSubmitted\nReady to Print\nConfirm Print\nPrinted"
+  },
+  {
+   "fieldname": "check_run_table",
+   "fieldtype": "HTML"
+  },
+  {
+   "fieldname": "posting_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Posting Date"
+  },
+  {
+   "fieldname": "payment_entry_format",
+   "fieldtype": "Link",
+   "label": "Payment Entry Format",
+   "options": "Print Format"
+  },
+  {
+   "fieldname": "secondary_print_format",
+   "fieldtype": "Link",
+   "label": "Secondary Print Format",
+   "options": "Print Format"
+  }
+ ],
+ "is_submittable": 1,
+ "links": [],
+ "modified": "2024-05-08 20:06:22.394409",
+ "modified_by": "Administrator",
+ "module": "Check Run",
+ "name": "Check Run",
+ "naming_rule": "Expression (old style)",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts User",
+   "select": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts Manager",
+   "select": 1,
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  }
+ ],
+ "quick_entry": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1,
+ "track_seen": 1,
+ "track_views": 1
 }

--- a/check_run/check_run/doctype/check_run/check_run.py
+++ b/check_run/check_run/doctype/check_run/check_run.py
@@ -411,14 +411,16 @@ class CheckRun(Document):
 		frappe.enqueue_doc(
 			self.doctype,
 			self.name,
-			"render_check_pdf",
+			"render_check_run",
 			reprint_check_number=reprint_check_number,
 			queue="short",
 			now=True,
 		)
 
 	@frappe.whitelist()
-	def render_check_pdf(self: Self, reprint_check_number: int | None = None) -> None:
+	def render_check_run(
+		self: Self, reprint_check_number: int | None = None, pdf: bool = True
+	) -> None | str:
 		self.print_count = self.print_count + 1
 		self.set_status("Submitted")
 		if not frappe.db.exists("File", "Home/Check Run"):
@@ -433,6 +435,8 @@ class CheckRun(Document):
 		if reprint_check_number and reprint_check_number != "undefined":
 			self.initial_check_number = int(reprint_check_number)
 		output = PdfFileWriter()
+		se_print_output = PdfFileWriter()
+		html = []
 		transactions = json.loads(self.transactions)
 		check_increment = 0
 		_transactions = []
@@ -446,15 +450,33 @@ class CheckRun(Document):
 			mode_of_payment, docstatus = frappe.db.get_value(
 				"Payment Entry", pe, ["mode_of_payment", "docstatus"]
 			) or (None, None)
+			se_print_output = frappe.get_print(
+				"Payment Entry",
+				pe,
+				settings.secondary_print_format or frappe.get_meta("Payment Entry").default_print_format,
+				as_pdf=pdf,
+				output=se_print_output if pdf else "",
+				no_letterhead=0,
+			)
 			if docstatus == 1 and frappe.db.get_value("Mode of Payment", mode_of_payment, "type") == "Bank":
-				output = frappe.get_print(
-					"Payment Entry",
-					pe,
-					settings.print_format or frappe.get_meta("Payment Entry").default_print_format,
-					as_pdf=True,
-					output=output,
-					no_letterhead=0,
-				)
+				if pdf:
+					output = frappe.get_print(
+						"Payment Entry",
+						pe,
+						settings.print_format or frappe.get_meta("Payment Entry").default_print_format,
+						as_pdf=True,
+						output=output,
+						no_letterhead=0,
+					)
+				else:
+					_output = frappe.get_print(
+						"Payment Entry",
+						pe,
+						settings.print_format or frappe.get_meta("Payment Entry").default_print_format,
+						as_pdf=False,
+						no_letterhead=0,
+					)
+					html.append(_output)
 				if initial_check_number != reprint_check_number:
 					frappe.db.set_value(
 						"Payment Entry", pe, "reference_no", self.initial_check_number + check_increment
@@ -487,11 +509,24 @@ class CheckRun(Document):
 		self.db_set("status", "Ready to Print")
 		self.db_set("print_count", self.print_count)
 		frappe.db.set_value("Bank Account", self.bank_account, "check_number", self.final_check_number)
-		save_file(
-			f"{self.name}.pdf", read_multi_pdf(output), "Check Run", self.name, "Home/Check Run", False, 0
-		)
-		frappe.db.commit()
-		frappe.publish_realtime("reload", "{}", doctype=self.doctype, docname=self.name)
+		if pdf:
+			save_file(
+				f"{self.name}.pdf", read_multi_pdf(output), "Check Run", self.name, "Home/Check Run", False, 0
+			)
+			save_file(
+				f"{self.name}.pdf",
+				read_multi_pdf(se_print_output),
+				"Check Run",
+				self.name,
+				"Home/Check Run",
+				False,
+				0,
+			)
+			frappe.db.commit()
+			frappe.publish_realtime("reload", "{}", doctype=self.doctype, docname=self.name)
+			return None
+		else:
+			return '<p style="page-break-after: always;">&nbsp;</p>'.join(html)
 
 
 @frappe.whitelist()

--- a/check_run/hooks.py
+++ b/check_run/hooks.py
@@ -150,9 +150,10 @@ doc_events = {
 # Overriding Methods
 # ------------------------------
 #
-# override_whitelisted_methods = {
-# 	"frappe.desk.doctype.event.event.get_events": "check_run.event.get_events"
-# }
+override_whitelisted_methods = {
+	"frappe.www.printview.get_html_and_style": "check_run.print.get_html_and_style",
+	"frappe.printing.page.print.print.get_print_settings_to_show": "check_run.print.get_print_settings_to_show",
+}
 #
 # each overriding function accepts a `data` argument;
 # generated from the base implementation of the doctype dashboard,

--- a/check_run/print.py
+++ b/check_run/print.py
@@ -1,0 +1,103 @@
+import json
+
+import frappe
+from frappe.www.printview import get_html_and_style as frappe_get_html_and_style, get_print_style
+from frappe.printing.page.print.print import (
+	get_print_settings_to_show as frappe_get_print_settings_to_show,
+)
+
+from check_run.check_run.doctype.check_run.check_run import get_check_run_settings
+
+
+@frappe.whitelist()
+def get_html_and_style(
+	doc,
+	name=None,
+	print_format=None,
+	meta=None,
+	no_letterhead=None,
+	letterhead=None,
+	trigger_print=False,
+	style=None,
+	settings=None,
+	templates=None,
+):
+	if isinstance(doc, str) and isinstance(name, str):
+		doc = frappe.get_doc(doc, name)
+
+	if isinstance(doc, str):
+		doc = frappe.get_doc(json.loads(doc))
+	if doc.doctype == "Check Run":
+		return get_check_run_format(
+			doc,
+			name,
+			print_format,
+			meta,
+			no_letterhead,
+			letterhead,
+			trigger_print,
+			style,
+			settings,
+			templates,
+		)
+	return frappe_get_html_and_style(
+		doc,
+		name,
+		print_format,
+		meta,
+		no_letterhead,
+		letterhead,
+		trigger_print,
+		style,
+		settings,
+		templates,
+	)
+
+
+def get_check_run_format(
+	doc,
+	name=None,
+	print_format=None,
+	meta=None,
+	no_letterhead=None,
+	letterhead=None,
+	trigger_print=False,
+	style=None,
+	settings=None,
+	templates=None,
+):
+	settings = json.loads(settings) if isinstance(doc, str) else settings
+	check_run_settings = get_check_run_settings(doc)
+	if not settings:
+		settings = {}
+		settings["payment_entry_format"] = check_run_settings.print_format
+		settings["secondary_print_format"] = check_run_settings.secondary_print_format
+
+	html = doc.render_check_run(pdf=False)
+	return {"html": html, "style": get_print_style(style=style)}
+
+
+@frappe.whitelist()
+def get_print_settings_to_show(doctype, docname):
+	settings = get_check_run_settings(frappe.get_doc("Check Run", docname))
+	if doctype == "Check Run":
+		return [
+			{
+				"fieldname": "payment_entry_format",
+				"label": frappe._("Payment Entry Format"),
+				"fieldtype": "Link",
+				"options": "Print Format",
+				"default": settings.print_format,
+				"value": settings.print_format,
+				# set get_query field with filter for Payment Entry Doctype
+			},
+			{
+				"fieldname": "secondary_print_format",
+				"label": frappe._("Secondary Print Format"),
+				"fieldtype": "Link",
+				"options": "Print Format",
+				"default": settings.secondary_print_format,
+				"value": settings.secondary_print_format,
+			},
+		]
+	return frappe_get_print_settings_to_show(doctype, docname)


### PR DESCRIPTION
#211 

This is probably not be a good enough solution as-is and more drastic measures I think are required, namely a partial override of frappe/www/printview.py

<details>
<summary>Screenshot</summary>

![image](https://github.com/agritheory/check_run/assets/18033666/eae0cd6e-3548-47e3-a316-8d2047488198)

</details>

There should be three checks/ Payment Entries in this Check Run, only one renders on the preview page due to the inclusion of page break HTML. It's likely that a better technique for previewing page breaks will be required.

Given that one cannot render the Payment Entries of the Check Run until it is submitted, I think it makes sense to return nothing or an error message in that case.

It would also be preferable to have a dedicated page to preview the Check Run and handle that with specific route rules instead of overriding the print preview. This would give greater control of the configuration of the printing, including showing important options like starting check number, etc. 


