### PR TITLE
feat: handling keydown

### DIFF
--- a/check_run/check_run/doctype/check_run/check_run.js
+++ b/check_run/check_run/doctype/check_run/check_run.js
@@ -101,6 +101,17 @@ frappe.ui.form.on('Check Run', {
 			frm.settings = frm.doc.__onload.settings
 			frm.pay_to_account_currency = frm.doc.__onload.pay_to_account_currency
 		}
+
+		$(document).on('keydown', function (event) {
+			switch (event.key) {
+				case 'ArrowDown':
+					handleArrowDown(event, frm);
+					break;
+				case 'ArrowUp':
+					handleArrowUp(event, frm);
+					break;
+			}
+		});
 	},
 	pay_to_account: frm => {
 		get_entries(frm)
@@ -423,11 +434,37 @@ function check_settings(frm) {
 					() => {
 						frappe.set_route('Form', 'Check Run Settings', r)
 					},
-					() => {} //stay on this page
+					() => { } //stay on this page
 				)
 			} else {
 				frm.doc.__onload.settings_missing = false
 			}
 		})
 	}
+}
+
+function handleArrowDown(event, frm) {
+	if (window.check_run.selectedRow.value !== -1) return
+	event.preventDefault()
+	let row = check_run.focusRow || null
+	if (!row || row == document.getElementById('tableTransactions').lastElementChild) {
+		row = document.getElementById('tableTransactions').firstElementChild
+	} else {
+		row = check_run.focusRow.nextElementSibling;
+	}
+	row.focus()
+	check_run.focusRow = row
+}
+
+function handleArrowUp(event, frm) {
+	if (window.check_run.selectedRow.value !== -1) return
+	event.preventDefault()
+	let row = check_run.focusRow || null
+	if (!row || row == document.getElementById('tableTransactions').firstElementChild) {
+		row = document.getElementById('tableTransactions').lastElementChild
+	} else {
+		row = check_run.focusRow.previousElementSibling;
+	}
+	row.focus()
+	check_run.focusRow = row
 }

--- a/check_run/check_run/doctype/check_run/check_run.js
+++ b/check_run/check_run/doctype/check_run/check_run.js
@@ -105,13 +105,13 @@ frappe.ui.form.on('Check Run', {
 		$(document).on('keydown', function (event) {
 			switch (event.key) {
 				case 'ArrowDown':
-					handleArrowDown(event, frm);
-					break;
+					handleArrowDown(event, frm)
+					break
 				case 'ArrowUp':
-					handleArrowUp(event, frm);
-					break;
+					handleArrowUp(event, frm)
+					break
 			}
-		});
+		})
 	},
 	pay_to_account: frm => {
 		get_entries(frm)
@@ -434,7 +434,7 @@ function check_settings(frm) {
 					() => {
 						frappe.set_route('Form', 'Check Run Settings', r)
 					},
-					() => { } //stay on this page
+					() => {} //stay on this page
 				)
 			} else {
 				frm.doc.__onload.settings_missing = false
@@ -450,7 +450,7 @@ function handleArrowDown(event, frm) {
 	if (!row || row == document.getElementById('tableTransactions').lastElementChild) {
 		row = document.getElementById('tableTransactions').firstElementChild
 	} else {
-		row = check_run.focusRow.nextElementSibling;
+		row = check_run.focusRow.nextElementSibling
 	}
 	row.focus()
 	check_run.focusRow = row
@@ -463,7 +463,7 @@ function handleArrowUp(event, frm) {
 	if (!row || row == document.getElementById('tableTransactions').firstElementChild) {
 		row = document.getElementById('tableTransactions').lastElementChild
 	} else {
-		row = check_run.focusRow.previousElementSibling;
+		row = check_run.focusRow.previousElementSibling
 	}
 	row.focus()
 	check_run.focusRow = row

--- a/check_run/public/js/check_run/CheckRun.vue
+++ b/check_run/public/js/check_run/CheckRun.vue
@@ -51,15 +51,19 @@
 					<th v-else class="col col-sm-1">Check Number | Reference</th>
 				</tr>
 			</thead>
-			<tbody>
+			<tbody id="tableTransactions">
 				<template v-for="(item, i) in orderedTransactions">
 					<tr
 						v-if="partyIsInFilter(item.party)"
 						:key="i"
+						:id="i"
 						class="checkrun-row-container"
 						:class="{ selectedRow: selectedRow == i }"
 						tabindex="1"
-						@click="selectedRow = i">
+						@keydown.prevent.esc="handleEsc"
+						@keydown.prevent.space="handleSelectRow(i)"
+						@keydown="handleKeyPress(i, item.name)"
+						@click="handleSelectRow(i)">
 						<td style="text-align: left">{{ item.party_name || item.party }}</td>
 						<td style="text-align: left; white-space: nowrap">
 							<a :href="transactionUrl(item)" target="_blank">
@@ -102,7 +106,9 @@
 							<select
 								v-if="frm.doc.status == 'Draft'"
 								class="form-control form-select form-select-lg mb-3"
-								@change="onMOPChange(frm, $event, item.name)">
+								@change="onMOPChange(frm, $event, item.name)"
+								:ref="el => paymentSelects[item.name] = el"
+								:data-select="item.name">
 								<option v-for="mop in modes_of_payment" :selected="transactions[item.name].mode_of_payment == mop">
 									{{ mop }}
 								</option>
@@ -129,7 +135,7 @@
 	</div>
 </template>
 <script setup>
-import { computed, onMounted, ref, reactive, watch, unref } from 'vue'
+import { computed, onMounted, ref, reactive, watch, unref, nextTick } from 'vue'
 import ModeOfPaymentSummary from './ModeOfPaymentSummary.vue'
 
 frappe.provide('check_run')
@@ -138,8 +144,9 @@ let transactions = reactive(window.check_run.transactions)
 let filters = reactive(window.check_run.filters)
 let show_party_filter = ref(false)
 let selectAll = ref(false)
-let selectedRow = ref()
+let selectedRow = computed(() => unref(window.check_run.selectedRow))
 let location = ref(window.location)
+let paymentSelects = ref({});
 
 let orderedTransactions = computed(() => {
 	let r = unref(
@@ -234,6 +241,33 @@ function paymentEntryUrl(transaction) {
 		return ''
 	}
 	return encodeURI(`${frappe.urllib.get_base_url()}/app/payment-entry/${transaction.payment_entry}`)
+}
+
+function handleEsc(event) {
+	window.check_run.selectedRow.value = -1
+}
+
+function handleSelectRow(row) {
+	if (window.check_run.selectedRow.value === - 1 || row !== window.check_run.selectedRow.value) {
+		window.check_run.selectedRow.value = row
+	} else {
+		window.check_run.selectedRow.value = -1
+	}
+}
+
+function handleKeyPress(row, itemName, event) {
+    if (selectedRow.value === row) {
+        nextTick(() => {
+            const select = paymentSelects.value[itemName];
+            if (select) {
+                select.focus();
+                if (["ArrowUp", "ArrowDown"].includes(event?.key)) {
+                    const event = new Event("mousedown", { bubbles: true });
+                    select.dispatchEvent(event);
+                }
+            }
+        });
+    }
 }
 </script>
 <style scoped>

--- a/check_run/public/js/check_run/CheckRun.vue
+++ b/check_run/public/js/check_run/CheckRun.vue
@@ -226,6 +226,7 @@ function update_sort(key_name) {
 }
 
 function onMOPChange(frm, event, rowName) {
+	window.check_run.selectedRow.value = -1
 	transactions[rowName].mode_of_payment = modes_of_payment.value[event.target.selectedIndex]
 	frm.dirty()
 	frm.page.set_indicator('Unsaved', 'orange')
@@ -248,9 +249,8 @@ function handleEsc(item) {
 }
 
 function handleSelectRow(row, item) {
-	if (window.check_run.selectedRow.value === -1 || row !== window.check_run.selectedRow.value) {
-		window.check_run.selectedRow.value = row
-		togglePaySelect(item)
+	if (window.check_run.selectedRow.value === -1 || row !== window.check_run.selectedRow.value) {		
+		togglePaySelect(item, row)
 	} else {
 		window.check_run.selectedRow.value = -1
 		togglePayUnselect(item)
@@ -273,12 +273,18 @@ function handleKeyPress(row, itemName, event) {
 	}
 }
 
-function togglePaySelect(item) {
+function togglePaySelect(item, row) {
 	const rowName = item.name;
-	transactions[rowName].pay = true;
+	if (transactions[rowName].pay) {
+		transactions[rowName].pay = false;
+		return;
+	}
 
-	if (!transactions[rowName].mode_of_payment) 
+	transactions[rowName].pay = true;
+	if (!transactions[rowName].mode_of_payment || transactions[rowName].mode_of_payment === 'None') {
+		window.check_run.selectedRow.value = row
 		frappe.show_alert(__('Please add a Mode of Payment for this row'));
+	}
 }
 
 function togglePayUnselect(item) {

--- a/check_run/public/js/check_run/CheckRun.vue
+++ b/check_run/public/js/check_run/CheckRun.vue
@@ -107,7 +107,7 @@
 								v-if="frm.doc.status == 'Draft'"
 								class="form-control form-select form-select-lg mb-3"
 								@change="onMOPChange(frm, $event, item.name)"
-								:ref="el => paymentSelects[item.name] = el"
+								:ref="el => (paymentSelects[item.name] = el)"
 								:data-select="item.name">
 								<option v-for="mop in modes_of_payment" :selected="transactions[item.name].mode_of_payment == mop">
 									{{ mop }}
@@ -146,7 +146,7 @@ let show_party_filter = ref(false)
 let selectAll = ref(false)
 let selectedRow = computed(() => unref(window.check_run.selectedRow))
 let location = ref(window.location)
-let paymentSelects = ref({});
+let paymentSelects = ref({})
 
 let orderedTransactions = computed(() => {
 	let r = unref(
@@ -248,7 +248,7 @@ function handleEsc(event) {
 }
 
 function handleSelectRow(row) {
-	if (window.check_run.selectedRow.value === - 1 || row !== window.check_run.selectedRow.value) {
+	if (window.check_run.selectedRow.value === -1 || row !== window.check_run.selectedRow.value) {
 		window.check_run.selectedRow.value = row
 	} else {
 		window.check_run.selectedRow.value = -1
@@ -256,18 +256,18 @@ function handleSelectRow(row) {
 }
 
 function handleKeyPress(row, itemName, event) {
-    if (selectedRow.value === row) {
-        nextTick(() => {
-            const select = paymentSelects.value[itemName];
-            if (select) {
-                select.focus();
-                if (["ArrowUp", "ArrowDown"].includes(event?.key)) {
-                    const event = new Event("mousedown", { bubbles: true });
-                    select.dispatchEvent(event);
-                }
-            }
-        });
-    }
+	if (selectedRow.value === row) {
+		nextTick(() => {
+			const select = paymentSelects.value[itemName]
+			if (select) {
+				select.focus()
+				if (['ArrowUp', 'ArrowDown'].includes(event?.key)) {
+					const event = new Event('mousedown', { bubbles: true })
+					select.dispatchEvent(event)
+				}
+			}
+		})
+	}
 }
 </script>
 <style scoped>

--- a/check_run/public/js/check_run/CheckRun.vue
+++ b/check_run/public/js/check_run/CheckRun.vue
@@ -60,10 +60,9 @@
 						class="checkrun-row-container"
 						:class="{ selectedRow: selectedRow == i }"
 						tabindex="1"
-						@keydown.prevent.esc="handleEsc"
-						@keydown.prevent.space="handleSelectRow(i)"
-						@keydown="handleKeyPress(i, item.name)"
-						@click="handleSelectRow(i)">
+						@keydown.prevent.esc="handleEsc(item)"
+						@keydown.prevent.space="handleSelectRow(i, item)"
+						@keydown="handleKeyPress(i, item.name)">
 						<td style="text-align: left">{{ item.party_name || item.party }}</td>
 						<td style="text-align: left; white-space: nowrap">
 							<a :href="transactionUrl(item)" target="_blank">
@@ -243,16 +242,20 @@ function paymentEntryUrl(transaction) {
 	return encodeURI(`${frappe.urllib.get_base_url()}/app/payment-entry/${transaction.payment_entry}`)
 }
 
-function handleEsc(event) {
+function handleEsc(item) {
 	window.check_run.selectedRow.value = -1
+	togglePayUnselect(item)
 }
 
-function handleSelectRow(row) {
+function handleSelectRow(row, item) {
 	if (window.check_run.selectedRow.value === -1 || row !== window.check_run.selectedRow.value) {
 		window.check_run.selectedRow.value = row
+		togglePaySelect(item)
 	} else {
 		window.check_run.selectedRow.value = -1
+		togglePayUnselect(item)
 	}
+	check_run.total(frm);
 }
 
 function handleKeyPress(row, itemName, event) {
@@ -268,6 +271,20 @@ function handleKeyPress(row, itemName, event) {
 			}
 		})
 	}
+}
+
+function togglePaySelect(item) {
+	const rowName = item.name;
+	transactions[rowName].pay = true;
+
+	if (!transactions[rowName].mode_of_payment) 
+		frappe.show_alert(__('Please add a Mode of Payment for this row'));
+}
+
+function togglePayUnselect(item) {
+	const rowName = item.name;
+	if (!transactions[rowName].mode_of_payment)
+		transactions[rowName].pay = false;
 }
 </script>
 <style scoped>
@@ -297,5 +314,12 @@ function handleKeyPress(row, itemName, event) {
 
 .table tr {
 	height: 50px;
+}
+
+.table tr:focus-visible {
+	color: var(--text-color);
+    border-color: var(--gray-500);
+    outline: 0;
+    box-shadow: 0 0 0 2px rgba(104, 113, 120, 0.25);
 }
 </style>

--- a/check_run/public/js/check_run/check_run.js
+++ b/check_run/public/js/check_run/check_run.js
@@ -4,6 +4,7 @@ import { createApp, reactive, ref, unref } from 'vue'
 frappe.provide('check_run')
 
 check_run.transactions = reactive({})
+check_run.selectedRow = ref(-1)
 check_run.modes_of_payment = ref([])
 check_run.filters = reactive({
 	key: 'posting_date',

--- a/check_run/public/js/vite.config.js
+++ b/check_run/public/js/vite.config.js
@@ -19,7 +19,6 @@ export default defineConfig({
 		rollupOptions: {
 			output: {
 				chunkFileNames: 'chunks/[name].[hash].js',
-				assetFileNames: 'assets/[name].[hash].[ext]',
 			},
 		},
 	},

--- a/check_run/public/js/vite.config.js
+++ b/check_run/public/js/vite.config.js
@@ -9,13 +9,19 @@ export default defineConfig({
 		lib: {
 			entry: path.resolve(__dirname, './check_run/check_run.js'),
 			name: 'check_run',
-			fileName: format => `check_run.js`, // creates module only output
+			fileName: () => `check_run.js`, // creates module only output
 		},
 		outDir: './check_run/public/dist/js',
 		root: './',
 		target: 'es2015',
 		emptyOutDir: false,
 		minify: false,
+		rollupOptions: {
+			output: {
+				chunkFileNames: 'chunks/[name].[hash].js',
+				assetFileNames: 'assets/[name].[hash].[ext]',
+			},
+		},
 	},
 	optimizeDeps: {},
 	define: {


### PR DESCRIPTION
I added the following features on keydown:

- **Up/Down** arrow keys navigate through rows. If you're on the last row and press the Down key, it will focus the first row, and vice versa.
- **Spacebar** select or deselect the focused row
- If a row is focused, pressing **Up/Down** will open the Mode of Payment dropdown.
- **Esc** will deselect the row

Preview:

https://github.com/user-attachments/assets/9b699751-cf50-4412-bc1b-dcbf7ac66fcc



