### PR TITLE
[Backport version-15] test: backport posting date config tests, add pytest-order

### DIFF
--- a/check_run/tests/test_check_run.py
+++ b/check_run/tests/test_check_run.py
@@ -1,5 +1,7 @@
+# Copyright (c) 2025, AgriTheory and contributors
+# For license information, please see license.txt
+
 import datetime
-import json
 
 import frappe
 import pytest
@@ -38,6 +40,7 @@ def cr():  # return draft check run
 	return cr
 
 
+@pytest.mark.order(10)
 def test_get_entries(cr):
 	crs = get_check_run_settings(cr)
 	assert frappe.db.exists("Check Run Settings", crs)
@@ -51,6 +54,7 @@ def test_get_entries(cr):
 	assert len([doc.get("name") == f"ACC-PINV-{year}-00001 " for doc in cr.transactions]) > 1
 
 
+@pytest.mark.order(11)
 def test_process_check_run_on_hold_invoice_error(cr):
 	cr.transactions = frappe.utils.safe_json_loads(cr.transactions)
 	# try to pay invoice on hold to raise error
@@ -68,6 +72,7 @@ def test_process_check_run_on_hold_invoice_error(cr):
 		cr.process_check_run()
 
 
+@pytest.mark.order(12)
 def test_process_check_run_on_hold_invoice_auto_release(cr):
 	# Test Settings auto-release of on-hold invoices
 	cr.transactions = frappe.utils.safe_json_loads(cr.transactions)
@@ -89,7 +94,18 @@ def test_process_check_run_on_hold_invoice_auto_release(cr):
 		pytest.fail("Error raised on Check Run process when should have passed.")
 
 
+@pytest.mark.order(13)
+def test_return_excluded_in_check_run(cr):
+	# Test for ValidationError when Check Run only includes a return transaction
+	cr.transactions = frappe.utils.safe_json_loads(cr.transactions)
+	for row in cr.transactions:
+		if row.get("party") == "Cooperative Ag Finance" and row.get("amount") < 0:
+			raise ValueError("Default Settings should exclude this invoice from appearing")
+
+
+@pytest.mark.order(14)
 def test_return_included_in_check_run_error(cr):
+	# Test for ValidationError when Check Run includes only a return transaction
 	_transactions = get_entries(cr).get("transactions")
 	settings = get_check_run_settings(cr)
 	assert settings.allow_stand_alone_debit_notes == "No"
@@ -110,10 +126,11 @@ def test_return_included_in_check_run_error(cr):
 		cr.process_check_run()
 
 
+@pytest.mark.order(15)
 def test_return_offset_other_amounts(cr):
+	# Test for offset when return applied to other invoices and net amount to pay is > 0
 	party = "Cooperative Ag Finance"
 
-	# Test for offset when return applied to other invoices and net amount to pay is > 0
 	cr.transactions = frappe.utils.safe_json_loads(cr.transactions)
 	total = 0.0
 	for row in cr.transactions:
@@ -126,4 +143,54 @@ def test_return_offset_other_amounts(cr):
 	cr.process_check_run()
 
 	pe = frappe.get_doc("Payment Entry", {"party": party, "check_run": cr.name})
-	assert total == pe.paid_amount
+	assert total == pe.paid_amount == 9000.00
+
+
+@pytest.mark.order(16)
+def test_default_posting_date_config(cr):
+	party = "HIJ Telecom, Inc"
+	crs = get_check_run_settings(cr)
+	assert crs.set_payment_entry_posting_date == "Use Today's Date"
+
+	cr.transactions = frappe.utils.safe_json_loads(cr.transactions)
+	# Pay one row for party
+	for row in cr.transactions:
+		if row.get("party") == party:
+			row["pay"] = True
+			break
+	cr.transactions = frappe.as_json(cr.transactions)
+	cr.flags.in_test = True
+	cr.save()
+	cr.process_check_run()
+
+	pe = frappe.get_doc("Payment Entry", {"party": party, "check_run": cr.name})
+	assert pe.posting_date == frappe.utils.getdate()
+
+
+@pytest.mark.order(17)
+def test_use_cr_posting_date_config(cr):
+	party = "HIJ Telecom, Inc"
+	crs = get_check_run_settings(cr)
+	assert crs.set_payment_entry_posting_date == "Use Today's Date"
+
+	crs.set_payment_entry_posting_date = "Use Check Run's Posting Date"
+	crs.save()
+	assert crs.set_payment_entry_posting_date == "Use Check Run's Posting Date"
+
+	cr.transactions = frappe.utils.safe_json_loads(cr.transactions)
+	# Pay one row for party
+	for row in cr.transactions:
+		if row.get("party") == party:
+			row["pay"] = True
+			break
+	cr.transactions = frappe.as_json(cr.transactions)
+	cr.flags.in_test = True
+	cr.save()
+	cr.process_check_run()
+
+	pe = frappe.get_doc("Payment Entry", {"party": party, "check_run": cr.name})
+	assert pe.posting_date == cr.posting_date
+
+	crs.set_payment_entry_posting_date = "Use Today's Date"
+	crs.save()
+	assert crs.set_payment_entry_posting_date == "Use Today's Date"

--- a/check_run/tests/test_payment_entry.py
+++ b/check_run/tests/test_payment_entry.py
@@ -1,19 +1,19 @@
+# Copyright (c) 2025, AgriTheory and contributors
+# For license information, please see license.txt
+
 import datetime
 
 import frappe
 import pytest
 from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
 
-from check_run.check_run.doctype.check_run.check_run import (
-	check_for_draft_check_run,
-	get_check_run_settings,
-	get_entries,
-)
-from check_run.tests.test_check_run import cr
+from check_run.check_run.doctype.check_run.check_run import get_entries
+from check_run.tests.test_check_run import cr  # noqa
 
 year = datetime.date.today().year
 
 
+@pytest.mark.order(20)
 def test_partial_payment_payment_entry_with_terms():
 	pi_name = frappe.get_all(
 		"Purchase Invoice",
@@ -49,6 +49,7 @@ def test_partial_payment_payment_entry_with_terms():
 	assert pi.outstanding_amount == 0.0
 
 
+@pytest.mark.order(21)
 def test_payment_payment_entry_of_multiple_terms():
 	pi_name = frappe.get_all(
 		"Purchase Invoice",
@@ -78,6 +79,7 @@ def test_payment_payment_entry_of_multiple_terms():
 	assert pi.payment_schedule[0].outstanding == 1666.67
 
 
+@pytest.mark.order(22)
 def test_partial_payment_payment_entry_without_terms():
 	pi_name = frappe.get_all(
 		"Purchase Invoice",
@@ -140,6 +142,7 @@ def test_partial_payment_payment_entry_without_terms():
 	assert pi.outstanding_amount == 0.00
 
 
+@pytest.mark.order(23)
 def test_outstanding_amount_in_check_run(cr):
 	pi_name = frappe.get_all(
 		"Purchase Invoice",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,9 @@ dynamic = ["version"]
 dependencies = [
     "atnacha @ git+https://github.com/AgriTheory/atnacha.git@main#egg=atnacha",
     "mypy",
-    "pytest"
+    "pytest",
+    "pdfplumber",
+    "pytest-order"
 ]
 
 [build-system]


### PR DESCRIPTION
Manually backports the new posting date config tests from #305 to `version-15` (I forgot to add the label to that PR). This PR also adds the `pytest-order` markers.

There's only one other test in `version-14` that's not in `version-15`, which is `test_pdf_length_and_mode_of_payment`. This PR does NOT include it as I see that's being backported separately with the other work around it from #290.