### PR TITLE
feat: check run settings quick entry override

### DIFF
--- a/check_run/public/js/check_run.bundle.js
+++ b/check_run/public/js/check_run.bundle.js
@@ -1,2 +1,3 @@
 import './check_run/check_run_quick_entry.js'
+import './check_run/check_run_settings_quick_entry.js'
 import './custom/file_preview.js'

--- a/check_run/public/js/check_run/check_run_settings_quick_entry.js
+++ b/check_run/public/js/check_run/check_run_settings_quick_entry.js
@@ -1,0 +1,75 @@
+frappe.provide('check_run')
+frappe.provide('frappe.ui.form')
+
+frappe.ui.form.CheckRunSettingsQuickEntryForm = class CheckRunQuickEntryForm extends frappe.ui.form.QuickEntryForm {
+	constructor(doctype, after_insert, init_callback, doc, force) {
+		super(doctype, after_insert, init_callback, doc, force)
+	}
+	render_dialog() {
+		this.mandatory = this.get_fields()
+		super.render_dialog()
+		this.dialog.$wrapper.find('.btn-secondary').hide()
+		this.dialog.fields_dict['bank_account'].get_query = () => {
+			return {
+				filters: {
+					is_company_account: 1,
+					company: this.dialog.get_field('company').value,
+				},
+			}
+		}
+		this.dialog.fields_dict['pay_to_account'].get_query = () => {
+			return {
+				filters: {
+					company: this.dialog.get_field('company').value,
+					account_type: 'Payable',
+				},
+			}
+		}
+		this.dialog.fields_dict['company'].df.onchange = () => {
+			this.default_accounts()
+		}
+		this.default_accounts()
+	}
+	get_fields() {
+		return [
+			{
+				label: __('Company'),
+				fieldname: 'company',
+				fieldtype: 'Link',
+				options: 'Company',
+				reqd: 1,
+			},
+			{
+				label: __('Paid From (Bank Account'),
+				fieldname: 'bank_account',
+				fieldtype: 'Link',
+				options: 'Bank Account',
+				reqd: 1,
+			},
+			{
+				label: __('Payable Account'),
+				fieldname: 'pay_to_account',
+				fieldtype: 'Link',
+				options: 'Account',
+				reqd: 1,
+			},
+		]
+	}
+	default_accounts() {
+		if (frappe.get_route() && frappe.get_route()[0] == 'Form') {
+			this.dialog.fields_dict['company'] = cur_frm.doc.company
+			this.dialog.fields_dict['pay_to_account'].set_value(cur_frm.doc.pay_to_account)
+			this.dialog.fields_dict['bank_account'].set_value(cur_frm.doc.bank_account)
+		} else {
+			let company = this.dialog.fields_dict.company.get_value()
+			frappe.db.get_value('Company', company, 'default_payable_account').then(r => {
+				this.dialog.fields_dict['pay_to_account'].set_value(r.message.default_payable_account)
+			})
+			frappe.db
+				.get_value('Bank Account', { company: company, is_default: 1, is_company_account: 1 }, 'name')
+				.then(r => {
+					this.dialog.fields_dict['bank_account'].set_value(r.message.name)
+				})
+		}
+	}
+}


### PR DESCRIPTION
Now, `Bank Account` and `Payable Account`fields preload their values correctly.

![Screenshot 2025-06-11 at 2 03 21 PM](https://github.com/user-attachments/assets/657398f7-7aa9-43a0-93af-5e43b4b9f10e)

Also, the `Payable Account` field now filters correctly.

![Screenshot 2025-06-11 at 2 00 29 PM](https://github.com/user-attachments/assets/e40f1312-2110-4fe2-829b-23a332fcf3ed)
