### PR TITLE
368 invoices with valid payment term discounts are not applied in check run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -302,7 +302,7 @@ Co-authored-by: agritheory <agritheory@users.noreply.github.com>
   ([#142](https://github.com/agritheory/check_run/pull/142),
   [`f07ad5a`](https://github.com/agritheory/check_run/commit/f07ad5a1c4a9b7e424ad534ec40731f26f6feb0c))
 
-- Only increment if check numer is numeric
+- Only increment if check number is numeric
   ([#139](https://github.com/agritheory/check_run/pull/139),
   [`079aa52`](https://github.com/agritheory/check_run/commit/079aa52bf013e13d3350848ef011b74b99b64bf1))
 

--- a/check_run/check_run/doctype/check_run/check_run.py
+++ b/check_run/check_run/doctype/check_run/check_run.py
@@ -828,7 +828,7 @@ def get_entries(doc: CheckRun | str) -> dict:
 	for transaction in transactions:
 		if transaction.doctype == "Purchase Invoice" and transaction.payment_term and posting_date:
 			discount_amount, has_discount = calculate_payment_term_discount(transaction, posting_date)
-			transaction.discount_amount = transaction.amount - discount_amount
+			transaction.discount_amount = transaction.amount - discount_amount if has_discount else 0.0
 			transaction.has_discount = has_discount
 		else:
 			transaction.has_discount = False

--- a/check_run/check_run/doctype/check_run/check_run.py
+++ b/check_run/check_run/doctype/check_run/check_run.py
@@ -18,7 +18,7 @@ from frappe.model.document import Document
 from frappe.permissions import has_permission
 from frappe.query_builder.custom import ConstantColumn
 from frappe.query_builder.functions import Coalesce, NullIf, Sum
-from frappe.utils.data import flt, get_datetime, getdate, now, nowdate, add_months, get_last_day
+from frappe.utils.data import add_months, flt, get_datetime, get_last_day, getdate, now, nowdate
 from frappe.utils.file_manager import remove_all, save_file
 from frappe.utils.password import get_decrypted_password
 from frappe.utils.print_format import read_multi_pdf
@@ -574,7 +574,9 @@ def calculate_payment_term_discount(
 		)
 	elif payment_term_doc.discount_validity_based_on == "Month(s) after the end of the invoice month":
 		last_day_of_month = get_last_day(transaction.posting_date)
-		discount_end_date = get_last_day(add_months(last_day_of_month, payment_term_doc.discount_validity))
+		discount_end_date = get_last_day(
+			add_months(last_day_of_month, payment_term_doc.discount_validity)
+		)
 
 	if payment_date > discount_end_date:
 		return 0.0, False

--- a/check_run/check_run/doctype/check_run/check_run.py
+++ b/check_run/check_run/doctype/check_run/check_run.py
@@ -351,12 +351,6 @@ class CheckRun(Document):
 					)
 
 				total_discount_amount = 0.0
-				payment_date = (
-					getdate()
-					if settings.set_payment_entry_posting_date == "Use Today's Date"
-					else self.posting_date
-				)
-
 				for reference in group:
 					if not reference:
 						continue
@@ -370,7 +364,7 @@ class CheckRun(Document):
 
 					discount_amount = 0.0
 					if reference.doctype == "Purchase Invoice" and reference.payment_term:
-						discount_amount, has_discount = calculate_payment_term_discount(reference, payment_date)
+						discount_amount, has_discount = calculate_payment_term_discount(reference, self.posting_date)
 						total_discount_amount += discount_amount
 
 					if reference.doctype == "Journal Entry":
@@ -576,10 +570,7 @@ class CheckRun(Document):
 		)
 
 
-def calculate_payment_term_discount(
-	transaction,
-	payment_date: datetime.date,
-) -> tuple[float, bool]:
+def calculate_payment_term_discount(transaction, payment_date):
 	if not transaction.payment_term:
 		return 0.0, False
 
@@ -828,15 +819,10 @@ def get_entries(doc: CheckRun | str) -> dict:
 
 	file_preview_allowed = False if len(transactions) > settings.file_preview_threshold else True
 
-	payment_date = (
-		getdate()
-		if settings and settings.set_payment_entry_posting_date == "Use Today's Date"
-		else doc.posting_date  # type: ignore
-	)
-
+	print("\npayment_date", settings.set_payment_entry_posting_date, doc.posting_date)
 	for transaction in transactions:
 		if transaction.doctype == "Purchase Invoice" and transaction.payment_term:
-			discount_amount, has_discount = calculate_payment_term_discount(transaction, payment_date)
+			discount_amount, has_discount = calculate_payment_term_discount(transaction, doc.posting_date)
 			transaction.discount_amount = transaction.amount - discount_amount
 			transaction.has_discount = has_discount
 		else:

--- a/check_run/check_run/doctype/check_run/check_run.py
+++ b/check_run/check_run/doctype/check_run/check_run.py
@@ -819,10 +819,10 @@ def get_entries(doc: CheckRun | str) -> dict:
 
 	file_preview_allowed = False if len(transactions) > settings.file_preview_threshold else True
 
-	print("\npayment_date", settings.set_payment_entry_posting_date, doc.posting_date)
 	for transaction in transactions:
-		if transaction.doctype == "Purchase Invoice" and transaction.payment_term:
-			discount_amount, has_discount = calculate_payment_term_discount(transaction, doc.posting_date)
+		posting_date = getattr(doc, "posting_date", None)
+		if transaction.doctype == "Purchase Invoice" and transaction.payment_term and posting_date:
+			discount_amount, has_discount = calculate_payment_term_discount(transaction, posting_date)
 			transaction.discount_amount = transaction.amount - discount_amount
 			transaction.has_discount = has_discount
 		else:

--- a/check_run/check_run/doctype/check_run/check_run.py
+++ b/check_run/check_run/doctype/check_run/check_run.py
@@ -59,6 +59,7 @@ class CheckRun(Document):
 		self.set_onload(
 			"is_approver_user", settings.approver_role in frappe.get_roles(frappe.session.user)
 		)
+		self.set_onload("payment_discount_account", getattr(settings, "payment_discount_account", None))
 
 	def validate(self) -> None:
 		gl_account = frappe.get_value("Bank Account", self.bank_account, "account")
@@ -388,11 +389,11 @@ class CheckRun(Document):
 					total_amount += reference.amount
 					reference.check_number = pe.reference_no
 					_references.append(reference)
-				pe.received_amount = total_amount
-				pe.base_received_amount = total_amount
-				pe.paid_amount = total_amount
-				pe.base_paid_amount = total_amount
-				pe.base_grand_total = total_amount
+				pe.received_amount = total_amount - total_discount_amount
+				pe.base_received_amount = total_amount - total_discount_amount
+				pe.paid_amount = total_amount - total_discount_amount
+				pe.base_paid_amount = total_amount - total_discount_amount
+				pe.base_grand_total = total_amount - total_discount_amount
 
 				if total_discount_amount > 0 and settings.payment_discount_account:
 					pe.append(

--- a/check_run/check_run/doctype/check_run/check_run.py
+++ b/check_run/check_run/doctype/check_run/check_run.py
@@ -18,7 +18,7 @@ from frappe.model.document import Document
 from frappe.permissions import has_permission
 from frappe.query_builder.custom import ConstantColumn
 from frappe.query_builder.functions import Coalesce, NullIf, Sum
-from frappe.utils.data import flt, get_datetime, getdate, now, nowdate
+from frappe.utils.data import flt, get_datetime, getdate, now, nowdate, add_months, get_last_day
 from frappe.utils.file_manager import remove_all, save_file
 from frappe.utils.password import get_decrypted_password
 from frappe.utils.print_format import read_multi_pdf
@@ -552,6 +552,42 @@ class CheckRun(Document):
 		)
 
 
+def calculate_payment_term_discount(
+	transaction,
+	payment_date: datetime.date,
+) -> tuple[float, bool]:
+	if not transaction.payment_term:
+		return 0.0, False
+
+	payment_term_doc = frappe.get_doc("Payment Term", transaction.payment_term)
+	if not payment_term_doc.discount or payment_term_doc.discount <= 0:
+		return 0.0, False
+
+	if payment_term_doc.discount_validity_based_on == "Day(s) after invoice date":
+		discount_end_date = transaction.posting_date + datetime.timedelta(
+			days=payment_term_doc.discount_validity
+		)
+	elif payment_term_doc.discount_validity_based_on == "Day(s) after the end of the invoice month":
+		last_day_of_month = get_last_day(transaction.posting_date)
+		discount_end_date = last_day_of_month + datetime.timedelta(
+			days=payment_term_doc.discount_validity
+		)
+	elif payment_term_doc.discount_validity_based_on == "Month(s) after the end of the invoice month":
+		last_day_of_month = get_last_day(transaction.posting_date)
+		discount_end_date = get_last_day(add_months(last_day_of_month, payment_term_doc.discount_validity))
+
+	if payment_date > discount_end_date:
+		return 0.0, False
+
+	discount_amount = 0.0
+	if payment_term_doc.discount_type == "Percentage":
+		discount_amount = transaction.amount * (payment_term_doc.discount / 100)
+	else:
+		discount_amount = min(payment_term_doc.discount, transaction.amount)
+
+	return discount_amount, True
+
+
 @frappe.whitelist()
 def check_for_draft_check_run(company: str, bank_account: str, payable_account: str) -> str:
 	existing = frappe.get_value(
@@ -766,7 +802,21 @@ def get_entries(doc: CheckRun | str) -> dict:
 
 	file_preview_allowed = False if len(transactions) > settings.file_preview_threshold else True
 
+	payment_date = (
+		getdate()
+		if settings and settings.set_payment_entry_posting_date == "Use Today's Date"
+		else doc.posting_date  # type: ignore
+	)
+
 	for transaction in transactions:
+		if transaction.doctype == "Purchase Invoice" and transaction.payment_term:
+			discount_amount, has_discount = calculate_payment_term_discount(transaction, payment_date)
+			transaction.amount = transaction.amount - discount_amount
+			transaction.has_discount = has_discount
+		else:
+			transaction.amount = transaction.amount
+			transaction.has_discount = False
+
 		if file_preview_allowed:
 			doc_name = transaction.ref_number if transaction.ref_number else transaction.name
 			transaction.attachments = [
@@ -795,6 +845,14 @@ def get_entries(doc: CheckRun | str) -> dict:
 
 		if transaction.due_date and settings.show_due_date == "Show Days Past Due":
 			transaction.due_date = (getdate(nowdate()) - transaction.due_date).days
+
+	has_discounts = any(t.get("has_discount") for t in transactions)
+	if has_discounts and settings and not settings.payment_discount_account:
+		frappe.throw(
+			frappe._(
+				"Payment Discount Account is required in Check Run Settings when processing invoices with payment term discounts. Please configure the Payment Discount Account in Check Run Settings."
+			)
+		)
 
 	outstanding_transaction = []
 	if not isinstance(doc, CheckRun):

--- a/check_run/check_run/doctype/check_run/check_run.py
+++ b/check_run/check_run/doctype/check_run/check_run.py
@@ -349,8 +349,8 @@ class CheckRun(Document):
 					pe.reference_no = frappe._(
 						f"via {_group[0].mode_of_payment} {self.get_formatted('posting_date')}"
 					)
-				
-				total_discount_amount = 0
+
+				total_discount_amount = 0.0
 				payment_date = (
 					getdate()
 					if settings.set_payment_entry_posting_date == "Use Today's Date"
@@ -367,12 +367,12 @@ class CheckRun(Document):
 					):
 						if frappe.get_value(reference.doctype, reference.name, "on_hold"):
 							frappe.db.set_value(reference.doctype, reference.name, "on_hold", 0)
-					
+
 					discount_amount = 0.0
 					if reference.doctype == "Purchase Invoice" and reference.payment_term:
 						discount_amount, has_discount = calculate_payment_term_discount(reference, payment_date)
 						total_discount_amount += discount_amount
-					
+
 					if reference.doctype == "Journal Entry":
 						reference_name = reference.ref_number
 					else:

--- a/check_run/check_run/doctype/check_run/check_run.py
+++ b/check_run/check_run/doctype/check_run/check_run.py
@@ -349,6 +349,13 @@ class CheckRun(Document):
 					pe.reference_no = frappe._(
 						f"via {_group[0].mode_of_payment} {self.get_formatted('posting_date')}"
 					)
+				
+				total_discount_amount = 0
+				payment_date = (
+					getdate()
+					if settings.set_payment_entry_posting_date == "Use Today's Date"
+					else self.posting_date
+				)
 
 				for reference in group:
 					if not reference:
@@ -360,6 +367,12 @@ class CheckRun(Document):
 					):
 						if frappe.get_value(reference.doctype, reference.name, "on_hold"):
 							frappe.db.set_value(reference.doctype, reference.name, "on_hold", 0)
+					
+					discount_amount = 0.0
+					if reference.doctype == "Purchase Invoice" and reference.payment_term:
+						discount_amount, has_discount = calculate_payment_term_discount(reference, payment_date)
+						total_discount_amount += discount_amount
+					
 					if reference.doctype == "Journal Entry":
 						reference_name = reference.ref_number
 					else:
@@ -386,6 +399,17 @@ class CheckRun(Document):
 				pe.paid_amount = total_amount
 				pe.base_paid_amount = total_amount
 				pe.base_grand_total = total_amount
+
+				if total_discount_amount > 0 and settings.payment_discount_account:
+					pe.append(
+						"deductions",
+						{
+							"account": settings.payment_discount_account,
+							"amount": -total_discount_amount,
+							"cost_center": frappe.get_value("Company", self.company, "cost_center"),
+						},
+					)
+
 				if not pe.get("references"):  # already paid or cancelled
 					continue
 				try:
@@ -813,10 +837,9 @@ def get_entries(doc: CheckRun | str) -> dict:
 	for transaction in transactions:
 		if transaction.doctype == "Purchase Invoice" and transaction.payment_term:
 			discount_amount, has_discount = calculate_payment_term_discount(transaction, payment_date)
-			transaction.amount = transaction.amount - discount_amount
+			transaction.discount_amount = transaction.amount - discount_amount
 			transaction.has_discount = has_discount
 		else:
-			transaction.amount = transaction.amount
 			transaction.has_discount = False
 
 		if file_preview_allowed:

--- a/check_run/check_run/doctype/check_run/check_run.py
+++ b/check_run/check_run/doctype/check_run/check_run.py
@@ -820,8 +820,8 @@ def get_entries(doc: CheckRun | str) -> dict:
 
 	file_preview_allowed = False if len(transactions) > settings.file_preview_threshold else True
 
+	posting_date = getattr(doc, "posting_date", None)
 	for transaction in transactions:
-		posting_date = getattr(doc, "posting_date", None)
 		if transaction.doctype == "Purchase Invoice" and transaction.payment_term and posting_date:
 			discount_amount, has_discount = calculate_payment_term_discount(transaction, posting_date)
 			transaction.discount_amount = transaction.amount - discount_amount

--- a/check_run/check_run/doctype/check_run/check_run.py
+++ b/check_run/check_run/doctype/check_run/check_run.py
@@ -579,17 +579,21 @@ def calculate_payment_term_discount(transaction, payment_date):
 	if not payment_term_doc.discount or payment_term_doc.discount <= 0:
 		return 0.0, False
 
+	posting_date = (
+		getdate(transaction.posting_date)
+		if isinstance(transaction.posting_date, str)
+		else transaction.posting_date
+	)
+
 	if payment_term_doc.discount_validity_based_on == "Day(s) after invoice date":
-		discount_end_date = transaction.posting_date + datetime.timedelta(
-			days=payment_term_doc.discount_validity
-		)
+		discount_end_date = posting_date + datetime.timedelta(days=payment_term_doc.discount_validity)
 	elif payment_term_doc.discount_validity_based_on == "Day(s) after the end of the invoice month":
-		last_day_of_month = get_last_day(transaction.posting_date)
+		last_day_of_month = get_last_day(posting_date)
 		discount_end_date = last_day_of_month + datetime.timedelta(
 			days=payment_term_doc.discount_validity
 		)
 	elif payment_term_doc.discount_validity_based_on == "Month(s) after the end of the invoice month":
-		last_day_of_month = get_last_day(transaction.posting_date)
+		last_day_of_month = get_last_day(posting_date)
 		discount_end_date = get_last_day(
 			add_months(last_day_of_month, payment_term_doc.discount_validity)
 		)

--- a/check_run/check_run/doctype/check_run_settings/check_run_settings.json
+++ b/check_run/check_run/doctype/check_run_settings/check_run_settings.json
@@ -11,6 +11,7 @@
 		"approver_role",
 		"column_break_3",
 		"pay_to_account",
+		"payment_discount_account",
 		"print_format",
 		"section_break_4",
 		"include_purchase_invoices",
@@ -26,7 +27,6 @@
 		"set_payment_entry_posting_date",
 		"show_due_date",
 		"number_of_invoices_per_voucher",
-		"secondary_print_format",
 		"file_preview_threshold",
 		"allow_stand_alone_debit_notes",
 		"default_modes_of_payment_section_section",
@@ -316,10 +316,17 @@
 			"fieldtype": "Select",
 			"label": "Show Due Date",
 			"options": "Show Due Date\nShow Days Past Due"
+		},
+		{
+			"fieldname": "payment_discount_account",
+			"fieldtype": "Link",
+			"label": "Payment Discount Account",
+			"options": "Account",
+			"reqd": 1
 		}
 	],
 	"links": [],
-	"modified": "2025-06-22 14:56:43.637709",
+	"modified": "2025-07-28 12:45:04.422121",
 	"modified_by": "Administrator",
 	"module": "Check Run",
 	"name": "Check Run Settings",
@@ -352,6 +359,7 @@
 		}
 	],
 	"quick_entry": 1,
+	"row_format": "Dynamic",
 	"sort_field": "modified",
 	"sort_order": "DESC",
 	"states": [],

--- a/check_run/check_run/doctype/check_run_settings/check_run_settings.json
+++ b/check_run/check_run/doctype/check_run_settings/check_run_settings.json
@@ -1,366 +1,366 @@
 {
- "actions": [],
- "autoname": "format:ACC-CRS-{bank_account}-{pay_to_account}",
- "creation": "2022-08-22 14:43:43.533105",
- "doctype": "DocType",
- "editable_grid": 1,
- "engine": "InnoDB",
- "field_order": [
-  "company",
-  "bank_account",
-  "approver_role",
-  "column_break_3",
-  "pay_to_account",
-  "payment_discount_account",
-  "print_format",
-  "section_break_4",
-  "include_purchase_invoices",
-  "include_journal_entries",
-  "include_expense_claims",
-  "pre_check_overdue_items",
-  "automatically_release_on_hold_invoices",
-  "allow_cancellation",
-  "cascade_cancellation",
-  "validate_unique_check_number",
-  "split_by_address",
-  "column_break_9",
-  "set_payment_entry_posting_date",
-  "show_due_date",
-  "number_of_invoices_per_voucher",
-  "file_preview_threshold",
-  "allow_stand_alone_debit_notes",
-  "default_modes_of_payment_section_section",
-  "purchase_invoice",
-  "journal_entry",
-  "column_break_21",
-  "expense_claim",
-  "ach_settings_section",
-  "allow_only_verified_accounts_in_nacha_generation",
-  "ach_file_extension",
-  "ach_service_class_code",
-  "ach_standard_class_code",
-  "ach_description",
-  "column_break_27",
-  "immediate_origin",
-  "company_discretionary_data",
-  "custom_post_processing_hook",
-  "role_allowed_to_download_ach_file_multiple_times",
-  "positive_pay_settings_section",
-  "attach_positive_pay",
-  "positive_pay_file_format",
-  "csv_delimiter",
-  "csv_quoting"
- ],
- "fields": [
-  {
-   "fieldname": "company",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Company",
-   "options": "Company",
-   "reqd": 1
-  },
-  {
-   "fieldname": "bank_account",
-   "fieldtype": "Link",
-   "label": "Bank Account",
-   "options": "Bank Account",
-   "reqd": 1
-  },
-  {
-   "fieldname": "section_break_4",
-   "fieldtype": "Section Break"
-  },
-  {
-   "default": "1",
-   "fieldname": "include_purchase_invoices",
-   "fieldtype": "Check",
-   "label": "Include Purchase Invoices"
-  },
-  {
-   "default": "1",
-   "fieldname": "include_journal_entries",
-   "fieldtype": "Check",
-   "label": "Include Journal Entries "
-  },
-  {
-   "default": "1",
-   "fieldname": "include_expense_claims",
-   "fieldtype": "Check",
-   "label": "Include Expense Claims"
-  },
-  {
-   "default": "0",
-   "description": "Payment Entries will be unlinked when Check Run is cancelled",
-   "fieldname": "allow_cancellation",
-   "fieldtype": "Check",
-   "label": "Allow Cancellation"
-  },
-  {
-   "fieldname": "column_break_9",
-   "fieldtype": "Column Break"
-  },
-  {
-   "default": "ach",
-   "description": "Common file extensions are 'ach', 'txt' and 'dat'. Your bank may require one of these.",
-   "fieldname": "ach_file_extension",
-   "fieldtype": "Data",
-   "label": "ACH File Extension"
-  },
-  {
-   "default": "0",
-   "description": "Pre-Check all payables that have a due date greater than the Check Run's posting date",
-   "fieldname": "pre_check_overdue_items",
-   "fieldtype": "Check",
-   "label": "Pre-Check Overdue Items"
-  },
-  {
-   "default": "0",
-   "description": "When a Check Run is cancelled, all Payment Entries linked to it will also be cancelled. This is not recommended.",
-   "fieldname": "cascade_cancellation",
-   "fieldtype": "Check",
-   "label": "Cascade Cancellation"
-  },
-  {
-   "description": "Defaults to 5 if no value is provided",
-   "fieldname": "number_of_invoices_per_voucher",
-   "fieldtype": "Int",
-   "label": "Number of Invoices per Voucher",
-   "non_negative": 1
-  },
-  {
-   "fieldname": "column_break_3",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "pay_to_account",
-   "fieldtype": "Link",
-   "label": "Payable Account",
-   "options": "Account",
-   "reqd": 1
-  },
-  {
-   "fieldname": "ach_service_class_code",
-   "fieldtype": "Select",
-   "label": "ACH Service Class Code",
-   "options": "200\n220\n225"
-  },
-  {
-   "description": "PPD is only supported Entry format at this time",
-   "fieldname": "ach_standard_class_code",
-   "fieldtype": "Select",
-   "label": "ACH Standard Class Code",
-   "options": "PPD"
-  },
-  {
-   "fieldname": "ach_description",
-   "fieldtype": "Data",
-   "label": "ACH Description",
-   "length": 10
-  },
-  {
-   "fieldname": "print_format",
-   "fieldtype": "Link",
-   "label": "Print Format",
-   "options": "Print Format"
-  },
-  {
-   "default": "0",
-   "fieldname": "split_by_address",
-   "fieldtype": "Check",
-   "label": "Split Invoices by Address"
-  },
-  {
-   "fieldname": "ach_settings_section",
-   "fieldtype": "Section Break",
-   "label": "ACH Settings"
-  },
-  {
-   "fieldname": "column_break_21",
-   "fieldtype": "Column Break"
-  },
-  {
-   "default": "0",
-   "fieldname": "automatically_release_on_hold_invoices",
-   "fieldtype": "Check",
-   "label": "Automatically Release On Hold Invoices"
-  },
-  {
-   "fieldname": "immediate_origin",
-   "fieldtype": "Data",
-   "label": "Immediate Origin"
-  },
-  {
-   "fieldname": "company_discretionary_data",
-   "fieldtype": "Data",
-   "label": "Company Discretionary Data",
-   "length": 20
-  },
-  {
-   "fieldname": "custom_post_processing_hook",
-   "fieldtype": "Data",
-   "label": "Custom Post Processing Hook",
-   "read_only": 1
-  },
-  {
-   "fieldname": "default_modes_of_payment_section_section",
-   "fieldtype": "Section Break",
-   "label": "Default Modes of Payment Section"
-  },
-  {
-   "fieldname": "purchase_invoice",
-   "fieldtype": "Link",
-   "label": "Purchase Invoice",
-   "options": "Mode of Payment"
-  },
-  {
-   "fieldname": "journal_entry",
-   "fieldtype": "Link",
-   "label": "Journal Entry",
-   "options": "Mode of Payment"
-  },
-  {
-   "fieldname": "expense_claim",
-   "fieldtype": "Link",
-   "label": "Expense Claim",
-   "options": "Mode of Payment"
-  },
-  {
-   "fieldname": "column_break_27",
-   "fieldtype": "Column Break"
-  },
-  {
-   "default": "1000",
-   "description": "File preview is enabled up to this number of transactions",
-   "fieldname": "file_preview_threshold",
-   "fieldtype": "Int",
-   "label": "File Preview Threshold"
-  },
-  {
-   "default": "0",
-   "fieldname": "validate_unique_check_number",
-   "fieldtype": "Check",
-   "label": "Validate Unique Check Number"
-  },
-  {
-   "default": "No",
-   "fieldname": "allow_stand_alone_debit_notes",
-   "fieldtype": "Select",
-   "label": "Allow stand-alone debit notes?",
-   "options": "Yes\nNo"
-  },
-  {
-   "description": "Users with this role are allowed to download ACH file multiple times. Users without this role are allowed to download it only once.",
-   "fieldname": "role_allowed_to_download_ach_file_multiple_times",
-   "fieldtype": "Link",
-   "label": "Role Allowed to Download ACH File Multiple Times",
-   "options": "Role"
-  },
-  {
-   "default": "Use Today's Date",
-   "fieldname": "set_payment_entry_posting_date",
-   "fieldtype": "Select",
-   "label": "Set Payment Entry Posting Date",
-   "options": "Use Today's Date\nUse Check Run's Posting Date"
-  },
-  {
-   "fieldname": "approver_role",
-   "fieldtype": "Link",
-   "label": "Approver Role",
-   "options": "Role"
-  },
-  {
-   "default": "0",
-   "fieldname": "allow_only_verified_accounts_in_nacha_generation",
-   "fieldtype": "Check",
-   "label": "Allow only verified accounts in NACHA generation"
-  },
-  {
-   "fieldname": "positive_pay_settings_section",
-   "fieldtype": "Section Break",
-   "label": "Positive Pay Settings"
-  },
-  {
-   "default": "0",
-   "fieldname": "attach_positive_pay",
-   "fieldtype": "Check",
-   "label": "Automatically Generate and Attach Positive Pay to Check Run"
-  },
-  {
-   "default": "CSV",
-   "depends_on": "attach_positive_pay",
-   "fieldname": "positive_pay_file_format",
-   "fieldtype": "Select",
-   "label": "Positive Pay File Format",
-   "options": "CSV\nExcel"
-  },
-  {
-   "default": ",",
-   "depends_on": "eval:doc.attach_positive_pay && doc.positive_pay_file_format === \"CSV\"",
-   "fieldname": "csv_delimiter",
-   "fieldtype": "Data",
-   "label": "CSV Delimiter",
-   "length": 1
-  },
-  {
-   "default": "Non-numeric",
-   "depends_on": "eval:doc.attach_positive_pay && doc.positive_pay_file_format === \"CSV\"",
-   "fieldname": "csv_quoting",
-   "fieldtype": "Select",
-   "label": "CSV Quoting",
-   "options": "Minimal\nAll\nNon-numeric\nNone"
-  },
-  {
-   "default": "Show Due Date",
-   "fieldname": "show_due_date",
-   "fieldtype": "Select",
-   "label": "Show Due Date",
-   "options": "Show Due Date\nShow Days Past Due"
-  },
-  {
-   "fieldname": "payment_discount_account",
-   "fieldtype": "Link",
-   "label": "Payment Discount Account",
-   "options": "Account"
-  }
- ],
- "links": [],
- "modified": "2025-07-29 13:59:10.135620",
- "modified_by": "Administrator",
- "module": "Check Run",
- "name": "Check Run Settings",
- "naming_rule": "Expression",
- "owner": "Administrator",
- "permissions": [
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "System Manager",
-   "share": 1,
-   "write": 1
-  },
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "Accounts Manager",
-   "share": 1,
-   "write": 1
-  }
- ],
- "quick_entry": 1,
- "row_format": "Dynamic",
- "sort_field": "modified",
- "sort_order": "DESC",
- "states": [],
- "track_changes": 1
+	"actions": [],
+	"autoname": "format:ACC-CRS-{bank_account}-{pay_to_account}",
+	"creation": "2022-08-22 14:43:43.533105",
+	"doctype": "DocType",
+	"editable_grid": 1,
+	"engine": "InnoDB",
+	"field_order": [
+		"company",
+		"bank_account",
+		"approver_role",
+		"column_break_3",
+		"pay_to_account",
+		"payment_discount_account",
+		"print_format",
+		"section_break_4",
+		"include_purchase_invoices",
+		"include_journal_entries",
+		"include_expense_claims",
+		"pre_check_overdue_items",
+		"automatically_release_on_hold_invoices",
+		"allow_cancellation",
+		"cascade_cancellation",
+		"validate_unique_check_number",
+		"split_by_address",
+		"column_break_9",
+		"set_payment_entry_posting_date",
+		"show_due_date",
+		"number_of_invoices_per_voucher",
+		"file_preview_threshold",
+		"allow_stand_alone_debit_notes",
+		"default_modes_of_payment_section_section",
+		"purchase_invoice",
+		"journal_entry",
+		"column_break_21",
+		"expense_claim",
+		"ach_settings_section",
+		"allow_only_verified_accounts_in_nacha_generation",
+		"ach_file_extension",
+		"ach_service_class_code",
+		"ach_standard_class_code",
+		"ach_description",
+		"column_break_27",
+		"immediate_origin",
+		"company_discretionary_data",
+		"custom_post_processing_hook",
+		"role_allowed_to_download_ach_file_multiple_times",
+		"positive_pay_settings_section",
+		"attach_positive_pay",
+		"positive_pay_file_format",
+		"csv_delimiter",
+		"csv_quoting"
+	],
+	"fields": [
+		{
+			"fieldname": "company",
+			"fieldtype": "Link",
+			"in_list_view": 1,
+			"label": "Company",
+			"options": "Company",
+			"reqd": 1
+		},
+		{
+			"fieldname": "bank_account",
+			"fieldtype": "Link",
+			"label": "Bank Account",
+			"options": "Bank Account",
+			"reqd": 1
+		},
+		{
+			"fieldname": "section_break_4",
+			"fieldtype": "Section Break"
+		},
+		{
+			"default": "1",
+			"fieldname": "include_purchase_invoices",
+			"fieldtype": "Check",
+			"label": "Include Purchase Invoices"
+		},
+		{
+			"default": "1",
+			"fieldname": "include_journal_entries",
+			"fieldtype": "Check",
+			"label": "Include Journal Entries "
+		},
+		{
+			"default": "1",
+			"fieldname": "include_expense_claims",
+			"fieldtype": "Check",
+			"label": "Include Expense Claims"
+		},
+		{
+			"default": "0",
+			"description": "Payment Entries will be unlinked when Check Run is cancelled",
+			"fieldname": "allow_cancellation",
+			"fieldtype": "Check",
+			"label": "Allow Cancellation"
+		},
+		{
+			"fieldname": "column_break_9",
+			"fieldtype": "Column Break"
+		},
+		{
+			"default": "ach",
+			"description": "Common file extensions are 'ach', 'txt' and 'dat'. Your bank may require one of these.",
+			"fieldname": "ach_file_extension",
+			"fieldtype": "Data",
+			"label": "ACH File Extension"
+		},
+		{
+			"default": "0",
+			"description": "Pre-Check all payables that have a due date greater than the Check Run's posting date",
+			"fieldname": "pre_check_overdue_items",
+			"fieldtype": "Check",
+			"label": "Pre-Check Overdue Items"
+		},
+		{
+			"default": "0",
+			"description": "When a Check Run is cancelled, all Payment Entries linked to it will also be cancelled. This is not recommended.",
+			"fieldname": "cascade_cancellation",
+			"fieldtype": "Check",
+			"label": "Cascade Cancellation"
+		},
+		{
+			"description": "Defaults to 5 if no value is provided",
+			"fieldname": "number_of_invoices_per_voucher",
+			"fieldtype": "Int",
+			"label": "Number of Invoices per Voucher",
+			"non_negative": 1
+		},
+		{
+			"fieldname": "column_break_3",
+			"fieldtype": "Column Break"
+		},
+		{
+			"fieldname": "pay_to_account",
+			"fieldtype": "Link",
+			"label": "Payable Account",
+			"options": "Account",
+			"reqd": 1
+		},
+		{
+			"fieldname": "ach_service_class_code",
+			"fieldtype": "Select",
+			"label": "ACH Service Class Code",
+			"options": "200\n220\n225"
+		},
+		{
+			"description": "PPD is only supported Entry format at this time",
+			"fieldname": "ach_standard_class_code",
+			"fieldtype": "Select",
+			"label": "ACH Standard Class Code",
+			"options": "PPD"
+		},
+		{
+			"fieldname": "ach_description",
+			"fieldtype": "Data",
+			"label": "ACH Description",
+			"length": 10
+		},
+		{
+			"fieldname": "print_format",
+			"fieldtype": "Link",
+			"label": "Print Format",
+			"options": "Print Format"
+		},
+		{
+			"default": "0",
+			"fieldname": "split_by_address",
+			"fieldtype": "Check",
+			"label": "Split Invoices by Address"
+		},
+		{
+			"fieldname": "ach_settings_section",
+			"fieldtype": "Section Break",
+			"label": "ACH Settings"
+		},
+		{
+			"fieldname": "column_break_21",
+			"fieldtype": "Column Break"
+		},
+		{
+			"default": "0",
+			"fieldname": "automatically_release_on_hold_invoices",
+			"fieldtype": "Check",
+			"label": "Automatically Release On Hold Invoices"
+		},
+		{
+			"fieldname": "immediate_origin",
+			"fieldtype": "Data",
+			"label": "Immediate Origin"
+		},
+		{
+			"fieldname": "company_discretionary_data",
+			"fieldtype": "Data",
+			"label": "Company Discretionary Data",
+			"length": 20
+		},
+		{
+			"fieldname": "custom_post_processing_hook",
+			"fieldtype": "Data",
+			"label": "Custom Post Processing Hook",
+			"read_only": 1
+		},
+		{
+			"fieldname": "default_modes_of_payment_section_section",
+			"fieldtype": "Section Break",
+			"label": "Default Modes of Payment Section"
+		},
+		{
+			"fieldname": "purchase_invoice",
+			"fieldtype": "Link",
+			"label": "Purchase Invoice",
+			"options": "Mode of Payment"
+		},
+		{
+			"fieldname": "journal_entry",
+			"fieldtype": "Link",
+			"label": "Journal Entry",
+			"options": "Mode of Payment"
+		},
+		{
+			"fieldname": "expense_claim",
+			"fieldtype": "Link",
+			"label": "Expense Claim",
+			"options": "Mode of Payment"
+		},
+		{
+			"fieldname": "column_break_27",
+			"fieldtype": "Column Break"
+		},
+		{
+			"default": "1000",
+			"description": "File preview is enabled up to this number of transactions",
+			"fieldname": "file_preview_threshold",
+			"fieldtype": "Int",
+			"label": "File Preview Threshold"
+		},
+		{
+			"default": "0",
+			"fieldname": "validate_unique_check_number",
+			"fieldtype": "Check",
+			"label": "Validate Unique Check Number"
+		},
+		{
+			"default": "No",
+			"fieldname": "allow_stand_alone_debit_notes",
+			"fieldtype": "Select",
+			"label": "Allow stand-alone debit notes?",
+			"options": "Yes\nNo"
+		},
+		{
+			"description": "Users with this role are allowed to download ACH file multiple times. Users without this role are allowed to download it only once.",
+			"fieldname": "role_allowed_to_download_ach_file_multiple_times",
+			"fieldtype": "Link",
+			"label": "Role Allowed to Download ACH File Multiple Times",
+			"options": "Role"
+		},
+		{
+			"default": "Use Today's Date",
+			"fieldname": "set_payment_entry_posting_date",
+			"fieldtype": "Select",
+			"label": "Set Payment Entry Posting Date",
+			"options": "Use Today's Date\nUse Check Run's Posting Date"
+		},
+		{
+			"fieldname": "approver_role",
+			"fieldtype": "Link",
+			"label": "Approver Role",
+			"options": "Role"
+		},
+		{
+			"default": "0",
+			"fieldname": "allow_only_verified_accounts_in_nacha_generation",
+			"fieldtype": "Check",
+			"label": "Allow only verified accounts in NACHA generation"
+		},
+		{
+			"fieldname": "positive_pay_settings_section",
+			"fieldtype": "Section Break",
+			"label": "Positive Pay Settings"
+		},
+		{
+			"default": "0",
+			"fieldname": "attach_positive_pay",
+			"fieldtype": "Check",
+			"label": "Automatically Generate and Attach Positive Pay to Check Run"
+		},
+		{
+			"default": "CSV",
+			"depends_on": "attach_positive_pay",
+			"fieldname": "positive_pay_file_format",
+			"fieldtype": "Select",
+			"label": "Positive Pay File Format",
+			"options": "CSV\nExcel"
+		},
+		{
+			"default": ",",
+			"depends_on": "eval:doc.attach_positive_pay && doc.positive_pay_file_format === \"CSV\"",
+			"fieldname": "csv_delimiter",
+			"fieldtype": "Data",
+			"label": "CSV Delimiter",
+			"length": 1
+		},
+		{
+			"default": "Non-numeric",
+			"depends_on": "eval:doc.attach_positive_pay && doc.positive_pay_file_format === \"CSV\"",
+			"fieldname": "csv_quoting",
+			"fieldtype": "Select",
+			"label": "CSV Quoting",
+			"options": "Minimal\nAll\nNon-numeric\nNone"
+		},
+		{
+			"default": "Show Due Date",
+			"fieldname": "show_due_date",
+			"fieldtype": "Select",
+			"label": "Show Due Date",
+			"options": "Show Due Date\nShow Days Past Due"
+		},
+		{
+			"fieldname": "payment_discount_account",
+			"fieldtype": "Link",
+			"label": "Payment Discount Account",
+			"options": "Account"
+		}
+	],
+	"links": [],
+	"modified": "2025-07-29 13:59:10.135620",
+	"modified_by": "Administrator",
+	"module": "Check Run",
+	"name": "Check Run Settings",
+	"naming_rule": "Expression",
+	"owner": "Administrator",
+	"permissions": [
+		{
+			"create": 1,
+			"delete": 1,
+			"email": 1,
+			"export": 1,
+			"print": 1,
+			"read": 1,
+			"report": 1,
+			"role": "System Manager",
+			"share": 1,
+			"write": 1
+		},
+		{
+			"create": 1,
+			"delete": 1,
+			"email": 1,
+			"export": 1,
+			"print": 1,
+			"read": 1,
+			"report": 1,
+			"role": "Accounts Manager",
+			"share": 1,
+			"write": 1
+		}
+	],
+	"quick_entry": 1,
+	"row_format": "Dynamic",
+	"sort_field": "modified",
+	"sort_order": "DESC",
+	"states": [],
+	"track_changes": 1
 }

--- a/check_run/check_run/doctype/check_run_settings/check_run_settings.json
+++ b/check_run/check_run/doctype/check_run_settings/check_run_settings.json
@@ -1,367 +1,366 @@
 {
-	"actions": [],
-	"autoname": "format:ACC-CRS-{bank_account}-{pay_to_account}",
-	"creation": "2022-08-22 14:43:43.533105",
-	"doctype": "DocType",
-	"editable_grid": 1,
-	"engine": "InnoDB",
-	"field_order": [
-		"company",
-		"bank_account",
-		"approver_role",
-		"column_break_3",
-		"pay_to_account",
-		"payment_discount_account",
-		"print_format",
-		"section_break_4",
-		"include_purchase_invoices",
-		"include_journal_entries",
-		"include_expense_claims",
-		"pre_check_overdue_items",
-		"automatically_release_on_hold_invoices",
-		"allow_cancellation",
-		"cascade_cancellation",
-		"validate_unique_check_number",
-		"split_by_address",
-		"column_break_9",
-		"set_payment_entry_posting_date",
-		"show_due_date",
-		"number_of_invoices_per_voucher",
-		"file_preview_threshold",
-		"allow_stand_alone_debit_notes",
-		"default_modes_of_payment_section_section",
-		"purchase_invoice",
-		"journal_entry",
-		"column_break_21",
-		"expense_claim",
-		"ach_settings_section",
-		"allow_only_verified_accounts_in_nacha_generation",
-		"ach_file_extension",
-		"ach_service_class_code",
-		"ach_standard_class_code",
-		"ach_description",
-		"column_break_27",
-		"immediate_origin",
-		"company_discretionary_data",
-		"custom_post_processing_hook",
-		"role_allowed_to_download_ach_file_multiple_times",
-		"positive_pay_settings_section",
-		"attach_positive_pay",
-		"positive_pay_file_format",
-		"csv_delimiter",
-		"csv_quoting"
-	],
-	"fields": [
-		{
-			"fieldname": "company",
-			"fieldtype": "Link",
-			"in_list_view": 1,
-			"label": "Company",
-			"options": "Company",
-			"reqd": 1
-		},
-		{
-			"fieldname": "bank_account",
-			"fieldtype": "Link",
-			"label": "Bank Account",
-			"options": "Bank Account",
-			"reqd": 1
-		},
-		{
-			"fieldname": "section_break_4",
-			"fieldtype": "Section Break"
-		},
-		{
-			"default": "1",
-			"fieldname": "include_purchase_invoices",
-			"fieldtype": "Check",
-			"label": "Include Purchase Invoices"
-		},
-		{
-			"default": "1",
-			"fieldname": "include_journal_entries",
-			"fieldtype": "Check",
-			"label": "Include Journal Entries "
-		},
-		{
-			"default": "1",
-			"fieldname": "include_expense_claims",
-			"fieldtype": "Check",
-			"label": "Include Expense Claims"
-		},
-		{
-			"default": "0",
-			"description": "Payment Entries will be unlinked when Check Run is cancelled",
-			"fieldname": "allow_cancellation",
-			"fieldtype": "Check",
-			"label": "Allow Cancellation"
-		},
-		{
-			"fieldname": "column_break_9",
-			"fieldtype": "Column Break"
-		},
-		{
-			"default": "ach",
-			"description": "Common file extensions are 'ach', 'txt' and 'dat'. Your bank may require one of these.",
-			"fieldname": "ach_file_extension",
-			"fieldtype": "Data",
-			"label": "ACH File Extension"
-		},
-		{
-			"default": "0",
-			"description": "Pre-Check all payables that have a due date greater than the Check Run's posting date",
-			"fieldname": "pre_check_overdue_items",
-			"fieldtype": "Check",
-			"label": "Pre-Check Overdue Items"
-		},
-		{
-			"default": "0",
-			"description": "When a Check Run is cancelled, all Payment Entries linked to it will also be cancelled. This is not recommended.",
-			"fieldname": "cascade_cancellation",
-			"fieldtype": "Check",
-			"label": "Cascade Cancellation"
-		},
-		{
-			"description": "Defaults to 5 if no value is provided",
-			"fieldname": "number_of_invoices_per_voucher",
-			"fieldtype": "Int",
-			"label": "Number of Invoices per Voucher",
-			"non_negative": 1
-		},
-		{
-			"fieldname": "column_break_3",
-			"fieldtype": "Column Break"
-		},
-		{
-			"fieldname": "pay_to_account",
-			"fieldtype": "Link",
-			"label": "Payable Account",
-			"options": "Account",
-			"reqd": 1
-		},
-		{
-			"fieldname": "ach_service_class_code",
-			"fieldtype": "Select",
-			"label": "ACH Service Class Code",
-			"options": "200\n220\n225"
-		},
-		{
-			"description": "PPD is only supported Entry format at this time",
-			"fieldname": "ach_standard_class_code",
-			"fieldtype": "Select",
-			"label": "ACH Standard Class Code",
-			"options": "PPD"
-		},
-		{
-			"fieldname": "ach_description",
-			"fieldtype": "Data",
-			"label": "ACH Description",
-			"length": 10
-		},
-		{
-			"fieldname": "print_format",
-			"fieldtype": "Link",
-			"label": "Print Format",
-			"options": "Print Format"
-		},
-		{
-			"default": "0",
-			"fieldname": "split_by_address",
-			"fieldtype": "Check",
-			"label": "Split Invoices by Address"
-		},
-		{
-			"fieldname": "ach_settings_section",
-			"fieldtype": "Section Break",
-			"label": "ACH Settings"
-		},
-		{
-			"fieldname": "column_break_21",
-			"fieldtype": "Column Break"
-		},
-		{
-			"default": "0",
-			"fieldname": "automatically_release_on_hold_invoices",
-			"fieldtype": "Check",
-			"label": "Automatically Release On Hold Invoices"
-		},
-		{
-			"fieldname": "immediate_origin",
-			"fieldtype": "Data",
-			"label": "Immediate Origin"
-		},
-		{
-			"fieldname": "company_discretionary_data",
-			"fieldtype": "Data",
-			"label": "Company Discretionary Data",
-			"length": 20
-		},
-		{
-			"fieldname": "custom_post_processing_hook",
-			"fieldtype": "Data",
-			"label": "Custom Post Processing Hook",
-			"read_only": 1
-		},
-		{
-			"fieldname": "default_modes_of_payment_section_section",
-			"fieldtype": "Section Break",
-			"label": "Default Modes of Payment Section"
-		},
-		{
-			"fieldname": "purchase_invoice",
-			"fieldtype": "Link",
-			"label": "Purchase Invoice",
-			"options": "Mode of Payment"
-		},
-		{
-			"fieldname": "journal_entry",
-			"fieldtype": "Link",
-			"label": "Journal Entry",
-			"options": "Mode of Payment"
-		},
-		{
-			"fieldname": "expense_claim",
-			"fieldtype": "Link",
-			"label": "Expense Claim",
-			"options": "Mode of Payment"
-		},
-		{
-			"fieldname": "column_break_27",
-			"fieldtype": "Column Break"
-		},
-		{
-			"default": "1000",
-			"description": "File preview is enabled up to this number of transactions",
-			"fieldname": "file_preview_threshold",
-			"fieldtype": "Int",
-			"label": "File Preview Threshold"
-		},
-		{
-			"default": "0",
-			"fieldname": "validate_unique_check_number",
-			"fieldtype": "Check",
-			"label": "Validate Unique Check Number"
-		},
-		{
-			"default": "No",
-			"fieldname": "allow_stand_alone_debit_notes",
-			"fieldtype": "Select",
-			"label": "Allow stand-alone debit notes?",
-			"options": "Yes\nNo"
-		},
-		{
-			"description": "Users with this role are allowed to download ACH file multiple times. Users without this role are allowed to download it only once.",
-			"fieldname": "role_allowed_to_download_ach_file_multiple_times",
-			"fieldtype": "Link",
-			"label": "Role Allowed to Download ACH File Multiple Times",
-			"options": "Role"
-		},
-		{
-			"default": "Use Today's Date",
-			"fieldname": "set_payment_entry_posting_date",
-			"fieldtype": "Select",
-			"label": "Set Payment Entry Posting Date",
-			"options": "Use Today's Date\nUse Check Run's Posting Date"
-		},
-		{
-			"fieldname": "approver_role",
-			"fieldtype": "Link",
-			"label": "Approver Role",
-			"options": "Role"
-		},
-		{
-			"default": "0",
-			"fieldname": "allow_only_verified_accounts_in_nacha_generation",
-			"fieldtype": "Check",
-			"label": "Allow only verified accounts in NACHA generation"
-		},
-		{
-			"fieldname": "positive_pay_settings_section",
-			"fieldtype": "Section Break",
-			"label": "Positive Pay Settings"
-		},
-		{
-			"default": "0",
-			"fieldname": "attach_positive_pay",
-			"fieldtype": "Check",
-			"label": "Automatically Generate and Attach Positive Pay to Check Run"
-		},
-		{
-			"default": "CSV",
-			"depends_on": "attach_positive_pay",
-			"fieldname": "positive_pay_file_format",
-			"fieldtype": "Select",
-			"label": "Positive Pay File Format",
-			"options": "CSV\nExcel"
-		},
-		{
-			"default": ",",
-			"depends_on": "eval:doc.attach_positive_pay && doc.positive_pay_file_format === \"CSV\"",
-			"fieldname": "csv_delimiter",
-			"fieldtype": "Data",
-			"label": "CSV Delimiter",
-			"length": 1
-		},
-		{
-			"default": "Non-numeric",
-			"depends_on": "eval:doc.attach_positive_pay && doc.positive_pay_file_format === \"CSV\"",
-			"fieldname": "csv_quoting",
-			"fieldtype": "Select",
-			"label": "CSV Quoting",
-			"options": "Minimal\nAll\nNon-numeric\nNone"
-		},
-		{
-			"default": "Show Due Date",
-			"fieldname": "show_due_date",
-			"fieldtype": "Select",
-			"label": "Show Due Date",
-			"options": "Show Due Date\nShow Days Past Due"
-		},
-		{
-			"fieldname": "payment_discount_account",
-			"fieldtype": "Link",
-			"label": "Payment Discount Account",
-			"options": "Account",
-			"reqd": 1
-		}
-	],
-	"links": [],
-	"modified": "2025-07-28 12:45:04.422121",
-	"modified_by": "Administrator",
-	"module": "Check Run",
-	"name": "Check Run Settings",
-	"naming_rule": "Expression",
-	"owner": "Administrator",
-	"permissions": [
-		{
-			"create": 1,
-			"delete": 1,
-			"email": 1,
-			"export": 1,
-			"print": 1,
-			"read": 1,
-			"report": 1,
-			"role": "System Manager",
-			"share": 1,
-			"write": 1
-		},
-		{
-			"create": 1,
-			"delete": 1,
-			"email": 1,
-			"export": 1,
-			"print": 1,
-			"read": 1,
-			"report": 1,
-			"role": "Accounts Manager",
-			"share": 1,
-			"write": 1
-		}
-	],
-	"quick_entry": 1,
-	"row_format": "Dynamic",
-	"sort_field": "modified",
-	"sort_order": "DESC",
-	"states": [],
-	"track_changes": 1
+ "actions": [],
+ "autoname": "format:ACC-CRS-{bank_account}-{pay_to_account}",
+ "creation": "2022-08-22 14:43:43.533105",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "company",
+  "bank_account",
+  "approver_role",
+  "column_break_3",
+  "pay_to_account",
+  "payment_discount_account",
+  "print_format",
+  "section_break_4",
+  "include_purchase_invoices",
+  "include_journal_entries",
+  "include_expense_claims",
+  "pre_check_overdue_items",
+  "automatically_release_on_hold_invoices",
+  "allow_cancellation",
+  "cascade_cancellation",
+  "validate_unique_check_number",
+  "split_by_address",
+  "column_break_9",
+  "set_payment_entry_posting_date",
+  "show_due_date",
+  "number_of_invoices_per_voucher",
+  "file_preview_threshold",
+  "allow_stand_alone_debit_notes",
+  "default_modes_of_payment_section_section",
+  "purchase_invoice",
+  "journal_entry",
+  "column_break_21",
+  "expense_claim",
+  "ach_settings_section",
+  "allow_only_verified_accounts_in_nacha_generation",
+  "ach_file_extension",
+  "ach_service_class_code",
+  "ach_standard_class_code",
+  "ach_description",
+  "column_break_27",
+  "immediate_origin",
+  "company_discretionary_data",
+  "custom_post_processing_hook",
+  "role_allowed_to_download_ach_file_multiple_times",
+  "positive_pay_settings_section",
+  "attach_positive_pay",
+  "positive_pay_file_format",
+  "csv_delimiter",
+  "csv_quoting"
+ ],
+ "fields": [
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Company",
+   "options": "Company",
+   "reqd": 1
+  },
+  {
+   "fieldname": "bank_account",
+   "fieldtype": "Link",
+   "label": "Bank Account",
+   "options": "Bank Account",
+   "reqd": 1
+  },
+  {
+   "fieldname": "section_break_4",
+   "fieldtype": "Section Break"
+  },
+  {
+   "default": "1",
+   "fieldname": "include_purchase_invoices",
+   "fieldtype": "Check",
+   "label": "Include Purchase Invoices"
+  },
+  {
+   "default": "1",
+   "fieldname": "include_journal_entries",
+   "fieldtype": "Check",
+   "label": "Include Journal Entries "
+  },
+  {
+   "default": "1",
+   "fieldname": "include_expense_claims",
+   "fieldtype": "Check",
+   "label": "Include Expense Claims"
+  },
+  {
+   "default": "0",
+   "description": "Payment Entries will be unlinked when Check Run is cancelled",
+   "fieldname": "allow_cancellation",
+   "fieldtype": "Check",
+   "label": "Allow Cancellation"
+  },
+  {
+   "fieldname": "column_break_9",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "ach",
+   "description": "Common file extensions are 'ach', 'txt' and 'dat'. Your bank may require one of these.",
+   "fieldname": "ach_file_extension",
+   "fieldtype": "Data",
+   "label": "ACH File Extension"
+  },
+  {
+   "default": "0",
+   "description": "Pre-Check all payables that have a due date greater than the Check Run's posting date",
+   "fieldname": "pre_check_overdue_items",
+   "fieldtype": "Check",
+   "label": "Pre-Check Overdue Items"
+  },
+  {
+   "default": "0",
+   "description": "When a Check Run is cancelled, all Payment Entries linked to it will also be cancelled. This is not recommended.",
+   "fieldname": "cascade_cancellation",
+   "fieldtype": "Check",
+   "label": "Cascade Cancellation"
+  },
+  {
+   "description": "Defaults to 5 if no value is provided",
+   "fieldname": "number_of_invoices_per_voucher",
+   "fieldtype": "Int",
+   "label": "Number of Invoices per Voucher",
+   "non_negative": 1
+  },
+  {
+   "fieldname": "column_break_3",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "pay_to_account",
+   "fieldtype": "Link",
+   "label": "Payable Account",
+   "options": "Account",
+   "reqd": 1
+  },
+  {
+   "fieldname": "ach_service_class_code",
+   "fieldtype": "Select",
+   "label": "ACH Service Class Code",
+   "options": "200\n220\n225"
+  },
+  {
+   "description": "PPD is only supported Entry format at this time",
+   "fieldname": "ach_standard_class_code",
+   "fieldtype": "Select",
+   "label": "ACH Standard Class Code",
+   "options": "PPD"
+  },
+  {
+   "fieldname": "ach_description",
+   "fieldtype": "Data",
+   "label": "ACH Description",
+   "length": 10
+  },
+  {
+   "fieldname": "print_format",
+   "fieldtype": "Link",
+   "label": "Print Format",
+   "options": "Print Format"
+  },
+  {
+   "default": "0",
+   "fieldname": "split_by_address",
+   "fieldtype": "Check",
+   "label": "Split Invoices by Address"
+  },
+  {
+   "fieldname": "ach_settings_section",
+   "fieldtype": "Section Break",
+   "label": "ACH Settings"
+  },
+  {
+   "fieldname": "column_break_21",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "automatically_release_on_hold_invoices",
+   "fieldtype": "Check",
+   "label": "Automatically Release On Hold Invoices"
+  },
+  {
+   "fieldname": "immediate_origin",
+   "fieldtype": "Data",
+   "label": "Immediate Origin"
+  },
+  {
+   "fieldname": "company_discretionary_data",
+   "fieldtype": "Data",
+   "label": "Company Discretionary Data",
+   "length": 20
+  },
+  {
+   "fieldname": "custom_post_processing_hook",
+   "fieldtype": "Data",
+   "label": "Custom Post Processing Hook",
+   "read_only": 1
+  },
+  {
+   "fieldname": "default_modes_of_payment_section_section",
+   "fieldtype": "Section Break",
+   "label": "Default Modes of Payment Section"
+  },
+  {
+   "fieldname": "purchase_invoice",
+   "fieldtype": "Link",
+   "label": "Purchase Invoice",
+   "options": "Mode of Payment"
+  },
+  {
+   "fieldname": "journal_entry",
+   "fieldtype": "Link",
+   "label": "Journal Entry",
+   "options": "Mode of Payment"
+  },
+  {
+   "fieldname": "expense_claim",
+   "fieldtype": "Link",
+   "label": "Expense Claim",
+   "options": "Mode of Payment"
+  },
+  {
+   "fieldname": "column_break_27",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "1000",
+   "description": "File preview is enabled up to this number of transactions",
+   "fieldname": "file_preview_threshold",
+   "fieldtype": "Int",
+   "label": "File Preview Threshold"
+  },
+  {
+   "default": "0",
+   "fieldname": "validate_unique_check_number",
+   "fieldtype": "Check",
+   "label": "Validate Unique Check Number"
+  },
+  {
+   "default": "No",
+   "fieldname": "allow_stand_alone_debit_notes",
+   "fieldtype": "Select",
+   "label": "Allow stand-alone debit notes?",
+   "options": "Yes\nNo"
+  },
+  {
+   "description": "Users with this role are allowed to download ACH file multiple times. Users without this role are allowed to download it only once.",
+   "fieldname": "role_allowed_to_download_ach_file_multiple_times",
+   "fieldtype": "Link",
+   "label": "Role Allowed to Download ACH File Multiple Times",
+   "options": "Role"
+  },
+  {
+   "default": "Use Today's Date",
+   "fieldname": "set_payment_entry_posting_date",
+   "fieldtype": "Select",
+   "label": "Set Payment Entry Posting Date",
+   "options": "Use Today's Date\nUse Check Run's Posting Date"
+  },
+  {
+   "fieldname": "approver_role",
+   "fieldtype": "Link",
+   "label": "Approver Role",
+   "options": "Role"
+  },
+  {
+   "default": "0",
+   "fieldname": "allow_only_verified_accounts_in_nacha_generation",
+   "fieldtype": "Check",
+   "label": "Allow only verified accounts in NACHA generation"
+  },
+  {
+   "fieldname": "positive_pay_settings_section",
+   "fieldtype": "Section Break",
+   "label": "Positive Pay Settings"
+  },
+  {
+   "default": "0",
+   "fieldname": "attach_positive_pay",
+   "fieldtype": "Check",
+   "label": "Automatically Generate and Attach Positive Pay to Check Run"
+  },
+  {
+   "default": "CSV",
+   "depends_on": "attach_positive_pay",
+   "fieldname": "positive_pay_file_format",
+   "fieldtype": "Select",
+   "label": "Positive Pay File Format",
+   "options": "CSV\nExcel"
+  },
+  {
+   "default": ",",
+   "depends_on": "eval:doc.attach_positive_pay && doc.positive_pay_file_format === \"CSV\"",
+   "fieldname": "csv_delimiter",
+   "fieldtype": "Data",
+   "label": "CSV Delimiter",
+   "length": 1
+  },
+  {
+   "default": "Non-numeric",
+   "depends_on": "eval:doc.attach_positive_pay && doc.positive_pay_file_format === \"CSV\"",
+   "fieldname": "csv_quoting",
+   "fieldtype": "Select",
+   "label": "CSV Quoting",
+   "options": "Minimal\nAll\nNon-numeric\nNone"
+  },
+  {
+   "default": "Show Due Date",
+   "fieldname": "show_due_date",
+   "fieldtype": "Select",
+   "label": "Show Due Date",
+   "options": "Show Due Date\nShow Days Past Due"
+  },
+  {
+   "fieldname": "payment_discount_account",
+   "fieldtype": "Link",
+   "label": "Payment Discount Account",
+   "options": "Account"
+  }
+ ],
+ "links": [],
+ "modified": "2025-07-29 13:59:10.135620",
+ "modified_by": "Administrator",
+ "module": "Check Run",
+ "name": "Check Run Settings",
+ "naming_rule": "Expression",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "quick_entry": 1,
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
 }

--- a/check_run/public/js/check_run/CheckRun.vue
+++ b/check_run/public/js/check_run/CheckRun.vue
@@ -154,8 +154,9 @@
 							</select>
 							<span v-else>{{ transactions[item.name].mode_of_payment }}</span>
 						</td>
-						<td>{{ format_currency(item.amount, frm.pay_to_account_currency, 2) }}</td>
-						<td>{{ item.due_date }}</td>
+						<td v-if="item.has_discount">{{ format_currency(item.discount_amount, frm.pay_to_account_currency, 2) }}</td>
+						<td v-else>{{ format_currency(item.amount, frm.pay_to_account_currency, 2) }}</td>
+						<td>{{ datetime.str_to_user(item.due_date) }}</td>
 						<td v-if="item.on_hold && frm.settings.automatically_release_on_hold_invoices == 0">
 							<span style="font-weight: bold">On Hold</span>
 						</td>

--- a/check_run/public/js/check_run/CheckRun.vue
+++ b/check_run/public/js/check_run/CheckRun.vue
@@ -154,7 +154,9 @@
 							</select>
 							<span v-else>{{ transactions[item.name].mode_of_payment }}</span>
 						</td>
-						<td v-if="item.has_discount">{{ format_currency(item.discount_amount, frm.pay_to_account_currency, 2) }}</td>
+						<td v-if="item.has_discount">
+							{{ format_currency(item.discount_amount, frm.pay_to_account_currency, 2) }}
+						</td>
 						<td v-else>{{ format_currency(item.amount, frm.pay_to_account_currency, 2) }}</td>
 						<td>{{ datetime.str_to_user(item.due_date) }}</td>
 						<td v-if="item.on_hold && frm.settings.automatically_release_on_hold_invoices == 0">

--- a/check_run/tests/setup.py
+++ b/check_run/tests/setup.py
@@ -264,7 +264,7 @@ def create_payment_terms_templates(settings):
 	if not frappe.db.exists("Payment Terms Template", "2% 10 Net 30"):
 		doc = frappe.new_doc("Payment Terms Template")
 		doc.template_name = "2% 10 Net 30"
-		
+
 		pt = frappe.new_doc("Payment Term")
 		pt.payment_term_name = "2% 10 Net 30"
 		pt.due_date_based_on = "Day(s) after the end of the invoice month"

--- a/check_run/tests/setup.py
+++ b/check_run/tests/setup.py
@@ -286,6 +286,83 @@ def create_payment_terms_templates(settings):
 		)
 		doc.save()
 
+	if not frappe.db.exists("Payment Terms Template", "3% 10 Net 30"):
+		doc = frappe.new_doc("Payment Terms Template")
+		doc.template_name = "3% 10 Net 30"
+
+		pt = frappe.new_doc("Payment Term")
+		pt.payment_term_name = "3% 10 Net 30"
+		pt.due_date_based_on = "Day(s) after the end of the invoice month"
+		pt.discount_validity_based_on = "Day(s) after the end of the invoice month"
+		pt.invoice_portion = 100
+		pt.credit_days = 30
+		pt.discount_type = "Amount"
+		pt.discount = 20.0
+		pt.discount_validity = 10
+		pt.save()
+		doc.append(
+			"terms",
+			{
+				"payment_term": pt.name,
+				"invoice_portion": pt.invoice_portion,
+				"due_date_based_on": pt.due_date_based_on,
+				"credit_days": pt.credit_days,
+			},
+		)
+		doc.save()
+
+	# Payment term with "Day(s) after invoice date" for discount validity
+	if not frappe.db.exists("Payment Terms Template", "2% 10 Net 30 - Invoice Date"):
+		doc = frappe.new_doc("Payment Terms Template")
+		doc.template_name = "2% 10 Net 30 - Invoice Date"
+
+		pt = frappe.new_doc("Payment Term")
+		pt.payment_term_name = "2% 10 Net 30 - Invoice Date"
+		pt.due_date_based_on = "Day(s) after invoice date"
+		pt.discount_validity_based_on = "Day(s) after invoice date"
+		pt.invoice_portion = 100
+		pt.credit_days = 30
+		pt.discount_type = "Percentage"
+		pt.discount = 2.0
+		pt.discount_validity = 10
+		pt.save()
+		doc.append(
+			"terms",
+			{
+				"payment_term": pt.name,
+				"invoice_portion": pt.invoice_portion,
+				"due_date_based_on": pt.due_date_based_on,
+				"credit_days": pt.credit_days,
+			},
+		)
+		doc.save()
+
+	# Payment term with "Month(s) after the end of the invoice month" for discount validity
+	if not frappe.db.exists("Payment Terms Template", "3% 10 Net 30 - Month End"):
+		doc = frappe.new_doc("Payment Terms Template")
+		doc.template_name = "3% 10 Net 30 - Month End"
+
+		pt = frappe.new_doc("Payment Term")
+		pt.payment_term_name = "3% 10 Net 30 - Month End"
+		pt.due_date_based_on = "Month(s) after the end of the invoice month"
+		pt.discount_validity_based_on = "Month(s) after the end of the invoice month"
+		pt.invoice_portion = 100
+		pt.credit_months = 1
+		pt.discount_type = "Percentage"
+		pt.discount = 3.0
+		pt.discount_validity = 1
+		pt.save()
+		doc.append(
+			"terms",
+			{
+				"payment_term": pt.name,
+				"invoice_portion": pt.invoice_portion,
+				"due_date_based_on": pt.due_date_based_on,
+				"credit_months": pt.credit_months,
+			},
+		)
+		doc.save()
+
 
 def create_suppliers(settings):
 	addresses = frappe._dict({})
@@ -512,17 +589,17 @@ def create_invoices(settings):
 	rpi.save()
 	rpi.submit()
 
-	# has discount
+	# has discount - recent date to qualify for discount
 	pi = frappe.new_doc("Purchase Invoice")
 	pi.company = settings.company
 	pi.set_posting_time = 1
 	pi.posting_date = datetime.date.today() - datetime.timedelta(days=7)
-	pi.supplier = suppliers[0][0]
+	pi.supplier = suppliers[3][0]
 	pi.payment_terms_template = "2% 10 Net 30"
 	pi.append(
 		"items",
 		{
-			"item_code": suppliers[0][1],
+			"item_code": suppliers[1][1],
 			"rate": 200.00,
 			"qty": 1,
 		},
@@ -530,18 +607,109 @@ def create_invoices(settings):
 	pi.save()
 	pi.submit()
 
-	# hasn't discount
+	# has discount - amount based discount
+	pi = frappe.new_doc("Purchase Invoice")
+	pi.company = settings.company
+	pi.set_posting_time = 1
+	pi.posting_date = datetime.date.today() - datetime.timedelta(days=5)
+	pi.supplier = suppliers[3][0]
+	pi.payment_terms_template = "3% 10 Net 30"
+	pi.append(
+		"items",
+		{
+			"item_code": suppliers[1][1],
+			"rate": 120.00,
+			"qty": 1,
+		},
+	)
+	pi.save()
+	pi.submit()
+
+	# hasn't discount - too old
 	pi = frappe.new_doc("Purchase Invoice")
 	pi.company = settings.company
 	pi.set_posting_time = 1
 	pi.posting_date = datetime.date.today() - datetime.timedelta(days=45)
-	pi.supplier = suppliers[1][0]
+	pi.supplier = suppliers[3][0]
 	pi.payment_terms_template = "2% 10 Net 30"
 	pi.append(
 		"items",
 		{
 			"item_code": suppliers[1][1],
 			"rate": 300.00,
+			"qty": 1,
+		},
+	)
+	pi.save()
+	pi.submit()
+
+	# Case last day of discount validity (Day(s) after invoice date)
+	pi = frappe.new_doc("Purchase Invoice")
+	pi.company = settings.company
+	pi.set_posting_time = 1
+	pi.posting_date = datetime.date.today() - datetime.timedelta(days=10)  # Exactly 10 days ago
+	pi.supplier = suppliers[2][0]
+	pi.payment_terms_template = "2% 10 Net 30 - Invoice Date"
+	pi.append(
+		"items",
+		{
+			"item_code": suppliers[2][1],
+			"rate": 500.00,
+			"qty": 1,
+		},
+	)
+	pi.save()
+	pi.submit()
+
+	# Case first day discount expires (Day(s) after invoice date)
+	pi = frappe.new_doc("Purchase Invoice")
+	pi.company = settings.company
+	pi.set_posting_time = 1
+	pi.posting_date = datetime.date.today() - datetime.timedelta(days=11)  # discount expired
+	pi.supplier = suppliers[2][0]
+	pi.payment_terms_template = "2% 10 Net 30 - Invoice Date"
+	pi.append(
+		"items",
+		{
+			"item_code": suppliers[2][1],
+			"rate": 400.00,
+			"qty": 1,
+		},
+	)
+	pi.save()
+	pi.submit()
+
+	# Case "Month(s) after the end of the invoice month"
+	first_of_month = datetime.date.today().replace(day=1)
+	pi = frappe.new_doc("Purchase Invoice")
+	pi.company = settings.company
+	pi.set_posting_time = 1
+	pi.posting_date = first_of_month - datetime.timedelta(days=5)  # Previous month
+	pi.supplier = suppliers[1][0]
+	pi.payment_terms_template = "3% 10 Net 30 - Month End"
+	pi.append(
+		"items",
+		{
+			"item_code": suppliers[1][1],
+			"rate": 250.00,
+			"qty": 1,
+		},
+	)
+	pi.save()
+	pi.submit()
+
+	# Case amount-based discount
+	pi = frappe.new_doc("Purchase Invoice")
+	pi.company = settings.company
+	pi.set_posting_time = 1
+	pi.posting_date = datetime.date.today() - datetime.timedelta(days=5)
+	pi.supplier = suppliers[0][0]
+	pi.payment_terms_template = "3% 10 Net 30"
+	pi.append(
+		"items",
+		{
+			"item_code": suppliers[0][1],
+			"rate": 100.00,
 			"qty": 1,
 		},
 	)

--- a/check_run/tests/setup.py
+++ b/check_run/tests/setup.py
@@ -286,12 +286,12 @@ def create_payment_terms_templates(settings):
 		)
 		doc.save()
 
-	if not frappe.db.exists("Payment Terms Template", "3% 10 Net 30"):
+	if not frappe.db.exists("Payment Terms Template", "$20 10 Net 30"):
 		doc = frappe.new_doc("Payment Terms Template")
-		doc.template_name = "3% 10 Net 30"
+		doc.template_name = "$20 10 Net 30"
 
 		pt = frappe.new_doc("Payment Term")
-		pt.payment_term_name = "3% 10 Net 30"
+		pt.payment_term_name = "$20 10 Net 30"
 		pt.due_date_based_on = "Day(s) after the end of the invoice month"
 		pt.discount_validity_based_on = "Day(s) after the end of the invoice month"
 		pt.invoice_portion = 100
@@ -338,12 +338,12 @@ def create_payment_terms_templates(settings):
 		doc.save()
 
 	# Payment term with "Month(s) after the end of the invoice month" for discount validity
-	if not frappe.db.exists("Payment Terms Template", "3% 10 Net 30 - Month End"):
+	if not frappe.db.exists("Payment Terms Template", "3% Net 30"):
 		doc = frappe.new_doc("Payment Terms Template")
-		doc.template_name = "3% 10 Net 30 - Month End"
+		doc.template_name = "3% Net 30"
 
 		pt = frappe.new_doc("Payment Term")
-		pt.payment_term_name = "3% 10 Net 30 - Month End"
+		pt.payment_term_name = "3% Net 30"
 		pt.due_date_based_on = "Month(s) after the end of the invoice month"
 		pt.discount_validity_based_on = "Month(s) after the end of the invoice month"
 		pt.invoice_portion = 100
@@ -613,7 +613,7 @@ def create_invoices(settings):
 	pi.set_posting_time = 1
 	pi.posting_date = datetime.date.today() - datetime.timedelta(days=5)
 	pi.supplier = suppliers[3][0]
-	pi.payment_terms_template = "3% 10 Net 30"
+	pi.payment_terms_template = "$20 10 Net 30"
 	pi.append(
 		"items",
 		{
@@ -686,7 +686,7 @@ def create_invoices(settings):
 	pi.set_posting_time = 1
 	pi.posting_date = first_of_month - datetime.timedelta(days=5)  # Previous month
 	pi.supplier = suppliers[1][0]
-	pi.payment_terms_template = "3% 10 Net 30 - Month End"
+	pi.payment_terms_template = "3% Net 30"
 	pi.append(
 		"items",
 		{
@@ -704,7 +704,7 @@ def create_invoices(settings):
 	pi.set_posting_time = 1
 	pi.posting_date = datetime.date.today() - datetime.timedelta(days=5)
 	pi.supplier = suppliers[0][0]
-	pi.payment_terms_template = "3% 10 Net 30"
+	pi.payment_terms_template = "$20 10 Net 30"
 	pi.append(
 		"items",
 		{

--- a/check_run/tests/setup.py
+++ b/check_run/tests/setup.py
@@ -261,6 +261,31 @@ def create_payment_terms_templates(settings):
 			)
 		doc.save()
 
+	if not frappe.db.exists("Payment Terms Template", "2% 10 Net 30"):
+		doc = frappe.new_doc("Payment Terms Template")
+		doc.template_name = "2% 10 Net 30"
+		
+		pt = frappe.new_doc("Payment Term")
+		pt.payment_term_name = "2% 10 Net 30"
+		pt.due_date_based_on = "Day(s) after the end of the invoice month"
+		pt.discount_validity_based_on = "Day(s) after the end of the invoice month"
+		pt.invoice_portion = 100
+		pt.credit_days = 30
+		pt.discount_type = "Percentage"
+		pt.discount = 2.0
+		pt.discount_validity = 10
+		pt.save()
+		doc.append(
+			"terms",
+			{
+				"payment_term": pt.name,
+				"invoice_portion": pt.invoice_portion,
+				"due_date_based_on": pt.due_date_based_on,
+				"credit_days": pt.credit_days,
+			},
+		)
+		doc.save()
+
 
 def create_suppliers(settings):
 	addresses = frappe._dict({})
@@ -486,6 +511,42 @@ def create_invoices(settings):
 	rpi.items[0].rate = 500
 	rpi.save()
 	rpi.submit()
+
+	# has discount
+	pi = frappe.new_doc("Purchase Invoice")
+	pi.company = settings.company
+	pi.set_posting_time = 1
+	pi.posting_date = datetime.date.today() - datetime.timedelta(days=7)
+	pi.supplier = suppliers[0][0]
+	pi.payment_terms_template = "2% 10 Net 30"
+	pi.append(
+		"items",
+		{
+			"item_code": suppliers[0][1],
+			"rate": 200.00,
+			"qty": 1,
+		},
+	)
+	pi.save()
+	pi.submit()
+
+	# hasn't discount
+	pi = frappe.new_doc("Purchase Invoice")
+	pi.company = settings.company
+	pi.set_posting_time = 1
+	pi.posting_date = datetime.date.today() - datetime.timedelta(days=45)
+	pi.supplier = suppliers[1][0]
+	pi.payment_terms_template = "2% 10 Net 30"
+	pi.append(
+		"items",
+		{
+			"item_code": suppliers[1][1],
+			"rate": 300.00,
+			"qty": 1,
+		},
+	)
+	pi.save()
+	pi.submit()
 
 
 def validate_release_date(self):

--- a/check_run/tests/test_check_run.py
+++ b/check_run/tests/test_check_run.py
@@ -287,17 +287,25 @@ def test_calculate_payment_term_discount_function():
 	]
 
 	for case in cases:
-		transaction = _dict({
-			"name": f"Test-{case['desc']}",
-			"payment_term": case["payment_term"],
-			"amount": case["amount"],
-			"posting_date": case["posting_date"],
-		})
+		transaction = _dict(
+			{
+				"name": f"Test-{case['desc']}",
+				"payment_term": case["payment_term"],
+				"amount": case["amount"],
+				"posting_date": case["posting_date"],
+			}
+		)
 		payment_date = datetime.date.today()
 		discount_amount, has_discount = calculate_payment_term_discount(transaction, payment_date)
 
-		assert abs(discount_amount - case["expected_discount"]) < 0.01, f"{case['desc']}: expected {case['expected_discount']}, obtained {discount_amount}"
-		assert has_discount == case["should_have_discount"], f"{case['desc']}: expected has_discount={case['should_have_discount']}, obtained {has_discount}"
+		assert (
+			abs(discount_amount - case["expected_discount"]) < 0.01
+		), f"{case['desc']}: expected {case['expected_discount']}, obtained {discount_amount}"
+		assert (
+			has_discount == case["should_have_discount"]
+		), (
+			f"{case['desc']}: expected has_discount={case['should_have_discount']}, obtained {has_discount}"
+		)
 
 
 @pytest.mark.order(19)

--- a/check_run/tests/test_check_run.py
+++ b/check_run/tests/test_check_run.py
@@ -5,8 +5,10 @@ import datetime
 
 import frappe
 import pytest
+from frappe import _dict
 
 from check_run.check_run.doctype.check_run.check_run import (
+	calculate_payment_term_discount,
 	check_for_draft_check_run,
 	get_check_run_settings,
 	get_entries,
@@ -213,3 +215,226 @@ def test_use_cr_posting_date_config(cr):
 	crs.set_payment_entry_posting_date = "Use Today's Date"
 	crs.save()
 	assert crs.set_payment_entry_posting_date == "Use Today's Date"
+
+
+@pytest.mark.order(18)
+def test_calculate_payment_term_discount_function():
+	cases = [
+		{
+			"desc": "2% 10 Net 30 - within the discount period",
+			"payment_term": "2% 10 Net 30",
+			"posting_date": datetime.date.today() - datetime.timedelta(days=5),
+			"amount": 1000.0,
+			"expected_discount": 1000.0 * 0.02,
+			"should_have_discount": True,
+		},
+		{
+			"desc": "2% 10 Net 30 - outside the discount period",
+			"payment_term": "2% 10 Net 30",
+			"posting_date": datetime.date.today() - datetime.timedelta(days=20),
+			"amount": 1000.0,
+			"expected_discount": 0.0,
+			"should_have_discount": False,
+		},
+		{
+			"desc": "3% 10 Net 30 - within the discount period",
+			"payment_term": "3% 10 Net 30",
+			"posting_date": datetime.date.today() - datetime.timedelta(days=8),
+			"amount": 500.0,
+			"expected_discount": min(20.0, 500.0),
+			"should_have_discount": True,
+		},
+		{
+			"desc": "3% 10 Net 30 - outside the discount period",
+			"payment_term": "3% 10 Net 30",
+			"posting_date": datetime.date.today() - datetime.timedelta(days=25),
+			"amount": 500.0,
+			"expected_discount": 0.0,
+			"should_have_discount": False,
+		},
+		{
+			"desc": "2% 10 Net 30 - Invoice Date - last valid day",
+			"payment_term": "2% 10 Net 30 - Invoice Date",
+			"posting_date": datetime.date.today() - datetime.timedelta(days=10),
+			"amount": 800.0,
+			"expected_discount": 800.0 * 0.02,
+			"should_have_discount": True,
+		},
+		{
+			"desc": "2% 10 Net 30 - Invoice Date - outside the discount period",
+			"payment_term": "2% 10 Net 30 - Invoice Date",
+			"posting_date": datetime.date.today() - datetime.timedelta(days=11),
+			"amount": 800.0,
+			"expected_discount": 0.0,
+			"should_have_discount": False,
+		},
+		{
+			"desc": "3% 10 Net 30 - Month End - within valid month",
+			"payment_term": "3% 10 Net 30 - Month End",
+			"posting_date": (datetime.date.today().replace(day=1) - datetime.timedelta(days=5)),
+			"amount": 600.0,
+			"expected_discount": 600.0 * 0.03,
+			"should_have_discount": True,
+		},
+		{
+			"desc": "3% 10 Net 30 - Month End - outside valid month",
+			"payment_term": "3% 10 Net 30 - Month End",
+			"posting_date": (datetime.date.today().replace(day=1) - datetime.timedelta(days=40)),
+			"amount": 600.0,
+			"expected_discount": 0.0,
+			"should_have_discount": False,
+		},
+	]
+
+	for case in cases:
+		transaction = _dict({
+			"name": f"Test-{case['desc']}",
+			"payment_term": case["payment_term"],
+			"amount": case["amount"],
+			"posting_date": case["posting_date"],
+		})
+		payment_date = datetime.date.today()
+		discount_amount, has_discount = calculate_payment_term_discount(transaction, payment_date)
+
+		assert abs(discount_amount - case["expected_discount"]) < 0.01, f"{case['desc']}: expected {case['expected_discount']}, obtained {discount_amount}"
+		assert has_discount == case["should_have_discount"], f"{case['desc']}: expected has_discount={case['should_have_discount']}, obtained {has_discount}"
+
+
+@pytest.mark.order(19)
+def test_cr_payment_term_discounts(cr):
+	cr.transactions = frappe.utils.safe_json_loads(cr.transactions)
+	payment_date = datetime.date.today()
+	test_cases = []
+
+	for row in cr.transactions:
+		if row.get("doctype") != "Purchase Invoice":
+			continue
+
+		payment_term = row.get("payment_term", "")
+		if not payment_term:
+			continue
+
+		invoice_name = row.get("name")
+		amount = row.get("amount")
+		posting_date = row.get("posting_date")
+
+		transaction = _dict(
+			{
+				"name": invoice_name,
+				"payment_term": payment_term,
+				"amount": amount,
+				"posting_date": posting_date,
+			}
+		)
+
+		# Calculate discount for this transaction using today's date
+		discount_amount, has_discount = calculate_payment_term_discount(transaction, payment_date)
+
+		test_case = {
+			"invoice": invoice_name,
+			"payment_term": payment_term,
+			"amount": amount,
+			"posting_date": posting_date,
+			"payment_date": payment_date,
+			"discount_amount": discount_amount,
+			"has_discount": has_discount,
+		}
+		test_cases.append(test_case)
+
+		if payment_term in [
+			"2% 10 Net 30",
+			"3% 10 Net 30",
+			"2% 10 Net 30 - Invoice Date",
+			"3% 10 Net 30 - Month End",
+		]:
+			row["pay"] = True
+			row["mode_of_payment"] = "Credit Card"
+
+	assert len(test_cases) > 0, "No payment term discount test cases found"
+
+	# Test Case 1: Invoices with percentage discounts (2%)
+	percentage_discount_cases = [tc for tc in test_cases if "2%" in tc["payment_term"]]
+	assert len(percentage_discount_cases) > 0, "No percentage discount test cases found"
+
+	for case in percentage_discount_cases:
+		if case["has_discount"]:
+			expected_discount = case["amount"] * 0.02
+			assert (
+				abs(case["discount_amount"] - expected_discount) < 0.01
+			), f"Percentage discount mismatch for {case['invoice']}: expected {expected_discount}, got {case['discount_amount']}"
+
+	# Test Case 2: Invoices with amount-based discounts (fixed amount)
+	amount_discount_cases = [tc for tc in test_cases if "3% 10 Net 30" in tc["payment_term"]]
+	for case in amount_discount_cases:
+		if case["has_discount"]:
+			if case["payment_term"] == "3% 10 Net 30 - Month End":
+				expected_discount = case["amount"] * 0.03
+			else:
+				expected_discount = min(20.0, case["amount"])
+
+			assert (
+				abs(case["discount_amount"] - expected_discount) < 0.01
+			), f"Amount discount mismatch for {case['invoice']}: expected {expected_discount}, got {case['discount_amount']}"
+
+	# Test Case 3: Expired discount scenarios
+	expired_cases = [tc for tc in test_cases if not tc["has_discount"]]
+	for case in expired_cases:
+		assert (
+			case["discount_amount"] == 0
+		), f"Expired discount should be 0 for {case['invoice']}, got {case['discount_amount']}"
+
+
+@pytest.mark.order(20)
+def test_cr_process_with_discounts(cr):
+	"""Test actual Check Run processing with discounts applied"""
+	cr.transactions = frappe.utils.safe_json_loads(cr.transactions)
+	payment_date = datetime.date.today()
+	total_expected_discount = 0
+	invoices_to_pay = []
+
+	for row in cr.transactions:
+		if row.get("doctype") == "Purchase Invoice" and row.get("payment_term") in [
+			"2% 10 Net 30",
+			"3% 10 Net 30",
+			"3% 10 Net 30 - Month End",
+			"2% 10 Net 30 - Invoice Date",
+		]:
+			row["pay"] = True
+			row["mode_of_payment"] = "Credit Card"
+
+			transaction = _dict(
+				{
+					"name": row["name"],
+					"payment_term": row["payment_term"],
+					"amount": row["amount"],
+					"posting_date": row["posting_date"],
+				}
+			)
+
+			discount_amount, has_discount = calculate_payment_term_discount(transaction, payment_date)
+
+			if has_discount:
+				total_expected_discount += discount_amount
+				invoices_to_pay.append(
+					{"name": row["name"], "amount": row["amount"], "expected_discount": discount_amount}
+				)
+
+	if len(invoices_to_pay) > 0:
+		cr.transactions = frappe.as_json(cr.transactions)
+		cr.flags.in_test = True
+		cr.save()
+		cr.process_check_run()
+
+		payment_entries = frappe.get_all(
+			"Payment Entry",
+			filters={"check_run": cr.name},
+			fields=["name", "total_allocated_amount", "paid_amount", "difference_amount"],
+		)
+		assert len(payment_entries) > 0, "No Payment Entries created"
+
+		# Check if any payment entry has discount
+		total_discount_in_pe = sum(pe.get("difference_amount", 0) for pe in payment_entries)
+		if total_expected_discount > 0:
+			assert (
+				len(payment_entries) > 0
+			), f"Expected Payment Entries to be created with discounts totaling {total_expected_discount}"

--- a/check_run/tests/test_check_run.py
+++ b/check_run/tests/test_check_run.py
@@ -219,11 +219,24 @@ def test_use_cr_posting_date_config(cr):
 
 @pytest.mark.order(18)
 def test_calculate_payment_term_discount_function():
+	# Create precise dates to test edge cases
+	today = datetime.date.today()
+	first_of_current_month = today.replace(day=1)
+	last_month = first_of_current_month - datetime.timedelta(days=1)
+	first_of_last_month = last_month.replace(day=1)
+	last_day_of_last_month = last_month
+	
+	# Simulate being on the 9th day of current month (within 10-day discount period)
+	simulated_today_within = first_of_current_month + datetime.timedelta(days=8)  # day 9
+	# Simulate being on the 12th day of current month (outside 10-day discount period)
+	simulated_today_outside = first_of_current_month + datetime.timedelta(days=11)  # day 12
+	
 	cases = [
 		{
 			"desc": "2% 10 Net 30 - within the discount period",
 			"payment_term": "2% 10 Net 30",
-			"posting_date": datetime.date.today() - datetime.timedelta(days=5),
+			"posting_date": first_of_last_month,  # Invoice on 1st of previous month
+			"payment_date": simulated_today_within,  # Payment on 9th of current month
 			"amount": 1000.0,
 			"expected_discount": 1000.0 * 0.02,
 			"should_have_discount": True,
@@ -231,23 +244,26 @@ def test_calculate_payment_term_discount_function():
 		{
 			"desc": "2% 10 Net 30 - outside the discount period",
 			"payment_term": "2% 10 Net 30",
-			"posting_date": datetime.date.today() - datetime.timedelta(days=20),
+			"posting_date": first_of_last_month,  # Invoice on 1st of previous month
+			"payment_date": simulated_today_outside,  # Payment on 12th of current month (outside period)
 			"amount": 1000.0,
 			"expected_discount": 0.0,
 			"should_have_discount": False,
 		},
 		{
-			"desc": "3% 10 Net 30 - within the discount period",
-			"payment_term": "3% 10 Net 30",
-			"posting_date": datetime.date.today() - datetime.timedelta(days=8),
+			"desc": "$20 10 Net 30 - within the discount period",
+			"payment_term": "$20 10 Net 30",
+			"posting_date": last_day_of_last_month,  # Invoice on last day of previous month
+			"payment_date": simulated_today_within,  # Payment on 9th of current month
 			"amount": 500.0,
 			"expected_discount": min(20.0, 500.0),
 			"should_have_discount": True,
 		},
 		{
-			"desc": "3% 10 Net 30 - outside the discount period",
-			"payment_term": "3% 10 Net 30",
-			"posting_date": datetime.date.today() - datetime.timedelta(days=25),
+			"desc": "$20 10 Net 30 - outside the discount period",
+			"payment_term": "$20 10 Net 30",
+			"posting_date": last_day_of_last_month,  # Invoice on last day of previous month
+			"payment_date": simulated_today_outside,  # Payment on 12th of current month (outside period)
 			"amount": 500.0,
 			"expected_discount": 0.0,
 			"should_have_discount": False,
@@ -255,7 +271,8 @@ def test_calculate_payment_term_discount_function():
 		{
 			"desc": "2% 10 Net 30 - Invoice Date - last valid day",
 			"payment_term": "2% 10 Net 30 - Invoice Date",
-			"posting_date": datetime.date.today() - datetime.timedelta(days=10),
+			"posting_date": today - datetime.timedelta(days=10),  # Exactly 10 days ago
+			"payment_date": today,
 			"amount": 800.0,
 			"expected_discount": 800.0 * 0.02,
 			"should_have_discount": True,
@@ -263,23 +280,26 @@ def test_calculate_payment_term_discount_function():
 		{
 			"desc": "2% 10 Net 30 - Invoice Date - outside the discount period",
 			"payment_term": "2% 10 Net 30 - Invoice Date",
-			"posting_date": datetime.date.today() - datetime.timedelta(days=11),
+			"posting_date": today - datetime.timedelta(days=11),  # 11 days ago (outside period)
+			"payment_date": today,
 			"amount": 800.0,
 			"expected_discount": 0.0,
 			"should_have_discount": False,
 		},
 		{
-			"desc": "3% 10 Net 30 - Month End - within valid month",
-			"payment_term": "3% 10 Net 30 - Month End",
-			"posting_date": (datetime.date.today().replace(day=1) - datetime.timedelta(days=5)),
+			"desc": "3% Net 30 - within valid month",
+			"payment_term": "3% Net 30",
+			"posting_date": first_of_last_month,  # Invoice from previous month
+			"payment_date": today,  # Payment today (within validity month)
 			"amount": 600.0,
 			"expected_discount": 600.0 * 0.03,
 			"should_have_discount": True,
 		},
 		{
-			"desc": "3% 10 Net 30 - Month End - outside valid month",
-			"payment_term": "3% 10 Net 30 - Month End",
-			"posting_date": (datetime.date.today().replace(day=1) - datetime.timedelta(days=40)),
+			"desc": "3% Net 30 - outside valid month",
+			"payment_term": "3% Net 30",
+			"posting_date": first_of_last_month - datetime.timedelta(days=32),  # Invoice from 2 months ago
+			"payment_date": today,  # Payment today (outside validity month)
 			"amount": 600.0,
 			"expected_discount": 0.0,
 			"should_have_discount": False,
@@ -295,7 +315,7 @@ def test_calculate_payment_term_discount_function():
 				"posting_date": case["posting_date"],
 			}
 		)
-		payment_date = datetime.date.today()
+		payment_date = case["payment_date"]
 		discount_amount, has_discount = calculate_payment_term_discount(transaction, payment_date)
 
 		assert (
@@ -351,9 +371,9 @@ def test_cr_payment_term_discounts(cr):
 
 		if payment_term in [
 			"2% 10 Net 30",
-			"3% 10 Net 30",
+			"$20 10 Net 30",
 			"2% 10 Net 30 - Invoice Date",
-			"3% 10 Net 30 - Month End",
+			"3% Net 30",
 		]:
 			row["pay"] = True
 			row["mode_of_payment"] = "Credit Card"
@@ -372,10 +392,10 @@ def test_cr_payment_term_discounts(cr):
 			), f"Percentage discount mismatch for {case['invoice']}: expected {expected_discount}, got {case['discount_amount']}"
 
 	# Test Case 2: Invoices with amount-based discounts (fixed amount)
-	amount_discount_cases = [tc for tc in test_cases if "3% 10 Net 30" in tc["payment_term"]]
+	amount_discount_cases = [tc for tc in test_cases if "$20 10 Net 30" in tc["payment_term"]]
 	for case in amount_discount_cases:
 		if case["has_discount"]:
-			if case["payment_term"] == "3% 10 Net 30 - Month End":
+			if case["payment_term"] == "3% Net 30":
 				expected_discount = case["amount"] * 0.03
 			else:
 				expected_discount = min(20.0, case["amount"])
@@ -403,8 +423,8 @@ def test_cr_process_with_discounts(cr):
 	for row in cr.transactions:
 		if row.get("doctype") == "Purchase Invoice" and row.get("payment_term") in [
 			"2% 10 Net 30",
-			"3% 10 Net 30",
-			"3% 10 Net 30 - Month End",
+			"$20 10 Net 30",
+			"3% Net 30",
 			"2% 10 Net 30 - Invoice Date",
 		]:
 			row["pay"] = True

--- a/check_run/tests/test_check_run.py
+++ b/check_run/tests/test_check_run.py
@@ -225,12 +225,12 @@ def test_calculate_payment_term_discount_function():
 	last_month = first_of_current_month - datetime.timedelta(days=1)
 	first_of_last_month = last_month.replace(day=1)
 	last_day_of_last_month = last_month
-	
+
 	# Simulate being on the 9th day of current month (within 10-day discount period)
 	simulated_today_within = first_of_current_month + datetime.timedelta(days=8)  # day 9
 	# Simulate being on the 12th day of current month (outside 10-day discount period)
 	simulated_today_outside = first_of_current_month + datetime.timedelta(days=11)  # day 12
-	
+
 	cases = [
 		{
 			"desc": "2% 10 Net 30 - within the discount period",

--- a/check_run/tests/test_payment_entry.py
+++ b/check_run/tests/test_payment_entry.py
@@ -13,7 +13,7 @@ from check_run.tests.test_check_run import cr  # noqa
 year = datetime.date.today().year
 
 
-@pytest.mark.order(20)
+@pytest.mark.order(30)
 def test_partial_payment_payment_entry_with_terms():
 	pi_name = frappe.get_all(
 		"Purchase Invoice",
@@ -49,7 +49,7 @@ def test_partial_payment_payment_entry_with_terms():
 	assert pi.outstanding_amount == 0.0
 
 
-@pytest.mark.order(21)
+@pytest.mark.order(31)
 def test_payment_payment_entry_of_multiple_terms():
 	pi_name = frappe.get_all(
 		"Purchase Invoice",
@@ -79,7 +79,7 @@ def test_payment_payment_entry_of_multiple_terms():
 	assert pi.payment_schedule[0].outstanding == 1666.67
 
 
-@pytest.mark.order(22)
+@pytest.mark.order(32)
 def test_partial_payment_payment_entry_without_terms():
 	pi_name = frappe.get_all(
 		"Purchase Invoice",
@@ -142,7 +142,7 @@ def test_partial_payment_payment_entry_without_terms():
 	assert pi.outstanding_amount == 0.00
 
 
-@pytest.mark.order(23)
+@pytest.mark.order(33)
 def test_outstanding_amount_in_check_run(cr):
 	pi_name = frappe.get_all(
 		"Purchase Invoice",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,3 +86,6 @@ env = "GH_TOKEN"
 [tool.semantic_release.publish]
 dist_glob_patterns = ["dist/*"]
 upload_to_vcs_release = true
+
+[tool.codespell]
+skip = "yarn.lock"


### PR DESCRIPTION
Resolves https://github.com/agritheory/check_run/issues/368

- Added 2 demo Purchase Invoices and a new Payment Terms Template.
- Added 2 keys to the transaction dictionary for Vue:`discount_amount` and `has_discount` (to show outstanding amount and discount status).
- Added a new field to Check Run Settings: Payment Discount Account.

## Demo

https://github.com/user-attachments/assets/76091a08-ae34-49b2-a494-c81001faaafc

Let me know if this is OK or if I should review any edge cases.
